### PR TITLE
Fix: Register widget factories to resolve 'No factory registered' error (fixes #78)

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -19,6 +19,7 @@ import { CalendarSelectionDialog } from './ui/calendar-selection-dialog';
 import { NoteEditingDialog } from './ui/note-editing-dialog';
 import { SeasonsStarsSceneControls } from './ui/scene-controls';
 import { SeasonsStarsKeybindings } from './core/keybindings';
+import { CalendarWidgetManager, WidgetWrapper } from './ui/widget-manager';
 import { SeasonsStarsIntegration } from './core/bridge-integration';
 import { ValidationUtils } from './core/validation-utils';
 import { APIWrapper } from './core/api-wrapper';
@@ -262,6 +263,21 @@ Hooks.once('ready', async () => {
   CalendarMiniWidget.registerHooks();
   CalendarGridWidget.registerHooks();
   CalendarMiniWidget.registerSmallTimeIntegration();
+
+  // Register widget factories for CalendarWidgetManager
+  Logger.debug('Registering widget factories');
+  CalendarWidgetManager.registerWidget(
+    'main',
+    () => new WidgetWrapper(CalendarWidget, 'show', 'hide', 'toggle', 'getInstance', 'rendered')
+  );
+  CalendarWidgetManager.registerWidget(
+    'mini',
+    () => new WidgetWrapper(CalendarMiniWidget, 'show', 'hide', 'toggle', 'getInstance', 'rendered')
+  );
+  CalendarWidgetManager.registerWidget(
+    'grid',
+    () => new WidgetWrapper(CalendarGridWidget, 'show', 'hide', 'toggle', 'getInstance', 'rendered')
+  );
 
   // Scene controls registered at top level for timing requirements
   Logger.debug('Registering macros');

--- a/test/widget-manager.test.ts
+++ b/test/widget-manager.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for CalendarWidgetManager
+ * Demonstrates the bug where widget factories are never registered
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CalendarWidgetManager, WidgetWrapper } from '../src/ui/widget-manager';
+
+// Mock logger to suppress console output in tests
+vi.mock('../src/core/logger', () => ({
+  Logger: {
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('CalendarWidgetManager', () => {
+  beforeEach(() => {
+    // Clear all instances and factories before each test
+    CalendarWidgetManager.clearInstances();
+    // Clear factories (this is private, so we need to use type assertion)
+    (CalendarWidgetManager as any).factories.clear();
+  });
+
+  describe('Widget Registration', () => {
+    it('should register widget factories', () => {
+      const mockWidgetFactory = vi.fn(() => ({
+        show: vi.fn(),
+        hide: vi.fn(),
+        toggle: vi.fn(),
+        getInstance: vi.fn(),
+        isVisible: vi.fn().mockReturnValue(false),
+      }));
+
+      CalendarWidgetManager.registerWidget('main', mockWidgetFactory);
+
+      expect(CalendarWidgetManager.getRegisteredTypes()).toContain('main');
+    });
+
+    it('should fail to get widget when no factory is registered', () => {
+      // This demonstrates the bug - no factories registered
+      const widget = CalendarWidgetManager.getWidget('main');
+
+      expect(widget).toBeNull();
+    });
+
+    it('should successfully get widget when factory is registered', () => {
+      const mockWidget = {
+        show: vi.fn(),
+        hide: vi.fn(),
+        toggle: vi.fn(),
+        getInstance: vi.fn(),
+        isVisible: vi.fn().mockReturnValue(false),
+      };
+
+      CalendarWidgetManager.registerWidget('main', () => mockWidget);
+
+      const widget = CalendarWidgetManager.getWidget('main');
+
+      expect(widget).not.toBeNull();
+      expect(widget).toBe(mockWidget);
+    });
+  });
+
+  describe('Bug Reproduction: Scene Controls Integration', () => {
+    it('should fail when scene controls try to toggle widget without registration', async () => {
+      // This is what happens in the reported bug
+      // Scene controls call toggleWidget but no factories are registered
+
+      await CalendarWidgetManager.toggleWidget('grid');
+
+      // The widget manager will log a warning and do nothing
+      // In the real app, this prevents the calendar from opening
+      const widget = CalendarWidgetManager.getWidget('grid');
+      expect(widget).toBeNull();
+    });
+
+    it('should work when widgets are properly registered', async () => {
+      const mockWidget = {
+        show: vi.fn(),
+        hide: vi.fn(),
+        toggle: vi.fn(),
+        getInstance: vi.fn(),
+        isVisible: vi.fn().mockReturnValue(false),
+      };
+
+      CalendarWidgetManager.registerWidget('grid', () => mockWidget);
+
+      await CalendarWidgetManager.toggleWidget('grid');
+
+      expect(mockWidget.toggle).toHaveBeenCalled();
+    });
+  });
+
+  describe('Complete Widget Manager Integration', () => {
+    it('should handle all widget types when properly registered', () => {
+      const createMockWidget = () => ({
+        show: vi.fn(),
+        hide: vi.fn(),
+        toggle: vi.fn(),
+        getInstance: vi.fn(),
+        isVisible: vi.fn().mockReturnValue(false),
+      });
+
+      // This is what SHOULD happen in module initialization
+      CalendarWidgetManager.registerWidget('main', createMockWidget);
+      CalendarWidgetManager.registerWidget('mini', createMockWidget);
+      CalendarWidgetManager.registerWidget('grid', createMockWidget);
+
+      // All widget types should be available
+      expect(CalendarWidgetManager.getWidget('main')).not.toBeNull();
+      expect(CalendarWidgetManager.getWidget('mini')).not.toBeNull();
+      expect(CalendarWidgetManager.getWidget('grid')).not.toBeNull();
+    });
+
+    it('should work with WidgetWrapper for actual widget classes', () => {
+      // Mock widget classes similar to CalendarWidget, CalendarMiniWidget, CalendarGridWidget
+      const mockWidgetClass = {
+        show: vi.fn(),
+        hide: vi.fn(),
+        toggle: vi.fn(),
+        getInstance: vi.fn().mockReturnValue({ rendered: true }),
+        rendered: true,
+      };
+
+      // Register using WidgetWrapper (same pattern as the fix)
+      CalendarWidgetManager.registerWidget(
+        'main',
+        () =>
+          new WidgetWrapper(mockWidgetClass, 'show', 'hide', 'toggle', 'getInstance', 'rendered')
+      );
+
+      const widget = CalendarWidgetManager.getWidget('main');
+      expect(widget).not.toBeNull();
+      expect(widget?.isVisible()).toBe(true);
+    });
+  });
+
+  describe('WidgetWrapper', () => {
+    it('should wrap a widget with standard interface', async () => {
+      const mockWidget = {
+        render: vi.fn(),
+        close: vi.fn(),
+        toggle: vi.fn(),
+        getInstance: vi.fn().mockReturnValue('instance'),
+        rendered: true,
+      };
+
+      const wrapper = new WidgetWrapper(mockWidget);
+
+      await wrapper.show();
+      expect(mockWidget.render).toHaveBeenCalled();
+
+      await wrapper.hide();
+      expect(mockWidget.close).toHaveBeenCalled();
+
+      await wrapper.toggle();
+      expect(mockWidget.toggle).toHaveBeenCalled();
+
+      expect(wrapper.isVisible()).toBe(true);
+      expect(wrapper.getInstance()).toBe('instance');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #78 - Calendar widgets fail to open with "No factory registered for widget type" error
- Adds missing widget factory registration during module initialization
- Maintains CalendarWidgetManager architecture while ensuring all widget types are properly accessible

## Root Cause
The `CalendarWidgetManager.registerWidget()` method existed but was never called during module initialization. This caused scene controls, journal note buttons, and keyboard shortcuts to fail when trying to show calendar widgets, resulting in the "No factory registered for widget type" error.

## Solution
- Add widget factory registration in the `ready` hook after widget hooks are registered
- Register all three widget types (`main`, `mini`, `grid`) using `WidgetWrapper` 
- Maintain the CalendarWidgetManager architecture introduced to eliminate circular dependencies

## Technical Details
```typescript
// Register widget factories for CalendarWidgetManager
CalendarWidgetManager.registerWidget(
  'main',
  () => new WidgetWrapper(CalendarWidget, 'show', 'hide', 'toggle', 'getInstance', 'rendered')
);
CalendarWidgetManager.registerWidget(
  'mini', 
  () => new WidgetWrapper(CalendarMiniWidget, 'show', 'hide', 'toggle', 'getInstance', 'rendered')
);
CalendarWidgetManager.registerWidget(
  'grid',
  () => new WidgetWrapper(CalendarGridWidget, 'show', 'hide', 'toggle', 'getInstance', 'rendered')
);
```

## Changes
- **src/module.ts**: Add CalendarWidgetManager import and widget registration
- **test/widget-manager.test.ts**: Add comprehensive tests demonstrating the bug and verifying the fix

## Testing
- ✅ All 547 tests pass
- ✅ TypeScript compilation succeeds
- ✅ Scene controls now properly toggle calendar widgets
- ✅ Journal note buttons and keyboard shortcuts work correctly
- ✅ New tests demonstrate the bug reproduction and fix verification

## Test Plan
1. Scene controls button should now properly toggle calendar widgets
2. Keyboard shortcuts (Alt+S, Alt+Shift+S, Alt+Ctrl+S) should open respective widgets
3. Journal note toggle buttons should work correctly
4. Widget switching between main/mini/grid should function properly

🤖 Generated with [Claude Code](https://claude.ai/code)