### PR TITLE
fix: Add missing seasons to WFRP calendar to resolve infinite loop

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -37,14 +37,16 @@ Seasons & Stars aims to provide a **reliable and extensible** calendar solution 
 
 ## 🚀 Planned Development
 
-### **v0.5.0 - Performance and Moon Tracking** (Next Release)
+### **v0.5.0 - Calendar Validation and Quality Assurance** (Next Release - **PRIORITY BUMPED**)
 
-**Focus**: Performance optimization and lunar cycle features
+**Focus**: Preventing calendar definition bugs that cause runtime errors
 
+- **JSON Schema Validation Tool**: Comprehensive calendar format validation to prevent bugs like Issue #83 ([#81](https://github.com/rayners/fvtt-seasons-and-stars/issues/81)) - **HIGH PRIORITY**
+- **Build-time Calendar Validation**: Catch incomplete calendar definitions before release
+- **Calendar Format Documentation**: Complete schema specification for calendar creators
 - **Lazy Calendar Loading**: Only load required calendars to improve startup performance and reduce errors ([#25](https://github.com/rayners/fvtt-seasons-and-stars/issues/25))
 - **Moon Phase Tracking**: Basic lunar cycle tracking for lycantropy, curses, and celestial events ([#17](https://github.com/rayners/fvtt-seasons-and-stars/issues/17))
 - **Performance Optimization**: Reduced memory usage and faster module initialization
-- **Calendar System Enhancement**: Better error handling and validation for calendar definitions
 
 ### **v0.6.0 - Notes System Enhancement** (High Priority)
 

--- a/calendars/warhammer.json
+++ b/calendars/warhammer.json
@@ -7,7 +7,7 @@
       "setting": "Warhammer Fantasy"
     }
   },
-  
+
   "year": {
     "epoch": 0,
     "currentYear": 2522,
@@ -15,11 +15,11 @@
     "suffix": "",
     "startDay": 0
   },
-  
+
   "leapYear": {
     "rule": "none"
   },
-  
+
   "months": [
     {
       "name": "Nachexen",
@@ -94,7 +94,7 @@
       "description": "Before Witching. The final month of the year, building toward the dangerous and magical time when dark powers reach their peak."
     }
   ],
-  
+
   "weekdays": [
     {
       "name": "Wellentag",
@@ -137,7 +137,7 @@
       "description": "Feast Day. The day of rest, celebration, and worship when the Empire's people gather to honor the gods"
     }
   ],
-  
+
   "intercalary": [
     {
       "name": "Hexenstag",
@@ -182,10 +182,41 @@
       "description": "Moon's Still. The winter solstice when darkness reaches its peak and the Empire huddles against the cold and supernatural threats."
     }
   ],
-  
+
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
     "secondsInMinute": 60
-  }
+  },
+
+  "seasons": [
+    {
+      "name": "Spring",
+      "startMonth": 2,
+      "endMonth": 4,
+      "icon": "spring",
+      "description": "The season of renewal when the Empire awakens from winter's grip. Jahrdrung begins the turn toward warmth, Pflugzeit brings preparation of fields, and Sigmarzeit embodies renewal and faith."
+    },
+    {
+      "name": "Summer",
+      "startMonth": 5,
+      "endMonth": 7,
+      "icon": "summer",
+      "description": "The bright season of growth and conflict. Sommerzeit sees crops flourish and armies march, while Vorgeheim and Nachgeheim bring mysterious forces and supernatural threats."
+    },
+    {
+      "name": "Autumn",
+      "startMonth": 8,
+      "endMonth": 9,
+      "icon": "fall",
+      "description": "The season of harvest and preparation. Erntezeit brings the crucial gathering of crops, while Brauzeit sees the preservation and brewing needed to survive the coming winter."
+    },
+    {
+      "name": "Winter",
+      "startMonth": 10,
+      "endMonth": 1,
+      "icon": "winter",
+      "description": "The harsh season of survival and dark magic. Kaldezeit and Ulriczeit test the Empire's endurance, while Vorhexen and Nachexen bring the most dangerous magical times of the year."
+    }
+  ]
 }

--- a/test/wfrp-seasons-fix-verification.test.ts
+++ b/test/wfrp-seasons-fix-verification.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Verification test for WFRP seasons fix (Issue #83)
+ * Tests that the WFRP calendar now has seasons to prevent infinite loop
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import type { SeasonsStarsCalendar } from '../src/types/calendar';
+
+describe('WFRP Seasons Fix Verification (Issue #83)', () => {
+  let warhammerData: SeasonsStarsCalendar;
+
+  it('should load WFRP calendar successfully', () => {
+    const warhammerPath = resolve('./calendars/warhammer.json');
+    warhammerData = JSON.parse(readFileSync(warhammerPath, 'utf8'));
+
+    expect(warhammerData.id).toBe('warhammer');
+    expect(warhammerData.translations.en.label).toBe('Imperial Calendar (Warhammer Fantasy)');
+  });
+
+  it('should have seasons property defined', () => {
+    expect(warhammerData.seasons).toBeDefined();
+    expect(Array.isArray(warhammerData.seasons)).toBe(true);
+    expect(warhammerData.seasons!.length).toBeGreaterThan(0);
+  });
+
+  it('should have exactly 4 seasons', () => {
+    expect(warhammerData.seasons).toHaveLength(4);
+
+    const seasonNames = warhammerData.seasons!.map(s => s.name);
+    expect(seasonNames).toEqual(['Spring', 'Summer', 'Autumn', 'Winter']);
+  });
+
+  it('should have properly configured season month ranges', () => {
+    const seasons = warhammerData.seasons!;
+
+    // Spring: Jahrdrung(2), Pflugzeit(3), Sigmarzeit(4)
+    expect(seasons[0].startMonth).toBe(2);
+    expect(seasons[0].endMonth).toBe(4);
+
+    // Summer: Sommerzeit(5), Vorgeheim(6), Nachgeheim(7)
+    expect(seasons[1].startMonth).toBe(5);
+    expect(seasons[1].endMonth).toBe(7);
+
+    // Autumn: Erntezeit(8), Brauzeit(9)
+    expect(seasons[2].startMonth).toBe(8);
+    expect(seasons[2].endMonth).toBe(9);
+
+    // Winter: Kaldezeit(10), Ulriczeit(11), Vorhexen(12), Nachexen(1)
+    expect(seasons[3].startMonth).toBe(10);
+    expect(seasons[3].endMonth).toBe(1); // Crosses year boundary
+  });
+
+  it('should have valid icons for all seasons', () => {
+    const seasons = warhammerData.seasons!;
+    const expectedIcons = ['spring', 'summer', 'fall', 'winter'];
+
+    seasons.forEach((season, index) => {
+      expect(season.icon).toBe(expectedIcons[index]);
+    });
+  });
+
+  it('should provide proper season coverage for all months', () => {
+    const seasons = warhammerData.seasons!;
+
+    // Test each month gets assigned to a season
+    for (let month = 1; month <= 12; month++) {
+      const season = seasons.find(s => {
+        if (s.startMonth! <= s.endMonth!) {
+          return month >= s.startMonth! && month <= s.endMonth!;
+        } else {
+          // Handle winter crossing year boundary
+          return month >= s.startMonth! || month <= s.endMonth!;
+        }
+      });
+
+      expect(season).toBeDefined();
+      console.log(`Month ${month}: ${season!.name}`);
+    }
+  });
+
+  it('should prevent the "No seasons found" warning that caused infinite loop', () => {
+    // This test simulates the condition that was causing the error loop
+    const calendar = warhammerData;
+
+    // Check the exact condition from module.ts line 961-964
+    const hasValidSeasons = !!(calendar && calendar.seasons && calendar.seasons.length > 0);
+
+    expect(hasValidSeasons).toBe(true);
+    console.log('✅ WFRP calendar now passes season validation');
+    console.log('✅ getSeasonInfo() will no longer trigger warning loop');
+  });
+});


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Resolves **Issue #83** - WFRP error reporting loop by adding missing `seasons` property to the WFRP calendar definition.

## Root Cause

The WFRP calendar (`calendars/warhammer.json`) was missing the required `seasons` property. When `getSeasonInfo()` was called, it triggered a "No seasons found" warning that created an infinite notification loop in the WFRP system context.

## Changes Made

- **Add seasons property to WFRP calendar** with proper Warhammer Fantasy month mappings:
  - **Spring**: Months 2-4 (Jahrdrung, Pflugzeit, Sigmarzeit)
  - **Summer**: Months 5-7 (Sommerzeit, Vorgeheim, Nachgeheim)  
  - **Autumn**: Months 8-9 (Erntezeit, Brauzeit)
  - **Winter**: Months 10-1 (Kaldezeit, Ulriczeit, Vorhexen, Nachexen)

- **Add comprehensive test suite** (`test/wfrp-seasons-fix-verification.test.ts`) to verify the fix

- **Prioritize Issue #81** (JSON Schema Validation) in roadmap to prevent similar bugs

## Test Plan

- [x] **WFRP calendar loads successfully** with seasons defined
- [x] **All 4 seasons configured** with proper month ranges
- [x] **Season coverage complete** - every month maps to a season  
- [x] **Validation passes** - calendar meets getSeasonInfo() requirements
- [x] **Existing WFRP tests still pass** - no regression in calendar functionality

## Quality Improvement

This bug highlighted a critical gap in quality assurance. **Issue #81 (JSON Schema Validation Tool) has been promoted to HIGH PRIORITY** in the v0.5.0 roadmap to prevent similar calendar definition bugs from reaching users.

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)