### PR TITLE
fix: widget synchronization issue for PF2e world creation timestamps

### DIFF
--- a/src/core/time-converter.ts
+++ b/src/core/time-converter.ts
@@ -102,7 +102,17 @@ export class TimeConverter {
    */
   private onWorldTimeUpdate(newTime: number, delta: number): void {
     this.lastKnownTime = newTime;
-    const dateResult = this.engine.worldTimeToDate(newTime);
+
+    // Allow system-specific integrations to provide world creation timestamp
+    let worldCreationTimestamp: number | undefined;
+    const currentSystem = game.system?.id;
+    if (currentSystem) {
+      const timestampData = { worldCreationTimestamp: undefined };
+      Hooks.callAll(`seasons-stars:${currentSystem}:getWorldCreationTimestamp`, timestampData);
+      worldCreationTimestamp = timestampData.worldCreationTimestamp;
+    }
+
+    const dateResult = this.engine.worldTimeToDate(newTime, worldCreationTimestamp);
     this.lastKnownDate =
       dateResult instanceof CalendarDate
         ? dateResult

--- a/src/integrations/pf2e-integration.ts
+++ b/src/integrations/pf2e-integration.ts
@@ -183,6 +183,25 @@ export class PF2eIntegration {
   }
 }
 
+// Hook to provide world creation timestamp to core S&S when requested
+Hooks.on(
+  'seasons-stars:pf2e:getWorldCreationTimestamp',
+  (timestampData: { worldCreationTimestamp: number | undefined }) => {
+    try {
+      const worldCreatedOn = (game as any).pf2e?.settings?.worldClock?.worldCreatedOn;
+      if (worldCreatedOn) {
+        const timestamp = new Date(worldCreatedOn).getTime() / 1000;
+        if (isFinite(timestamp) && timestamp > 0) {
+          timestampData.worldCreationTimestamp = timestamp;
+          Logger.debug('PF2e integration provided world creation timestamp:', timestamp);
+        }
+      }
+    } catch (error) {
+      Logger.error('PF2e integration failed to provide world creation timestamp:', error);
+    }
+  }
+);
+
 // Time monitoring - start periodic sync checking when ready
 Hooks.on('ready', () => {
   const integration = PF2eIntegration.getInstance();


### PR DESCRIPTION
## Summary
Fixes GitHub #91 comment issue where widgets showed different years (2700 epoch vs 4725 PF2e) after date changes due to missing world creation timestamp support in time converter hook emissions.

## Problem
The time converter's `onWorldTimeUpdate()` method was calling `engine.worldTimeToDate(newTime)` without the world creation timestamp parameter, causing widgets to receive epoch-based dates instead of PF2e-compatible dates through the `seasons-stars:dateChanged` hook.

## Solution
- **Enhanced time converter** to use system-specific hooks for world creation timestamps
- **Added hook pattern** `seasons-stars:${system}:getWorldCreationTimestamp` following existing integration patterns  
- **Updated PF2e integration** to respond with world creation timestamp from `game.pf2e.settings.worldClock.worldCreatedOn`
- **Maintains clean separation** - core S&S has zero PF2e knowledge

## Architecture Benefits
- ✅ **Uses established patterns** - matches existing `seasons-stars:pf2e:systemDetected` hook pattern
- ✅ **Backward compatible** - non-PF2e systems continue with epoch-based calculation  
- ✅ **Extensible design** - any system can provide world creation timestamps via hooks
- ✅ **Clean separation** - core time converter remains system-agnostic

## Test Results
- **Before**: Widgets showed 2700 (epoch) while PF2e showed 4725 (correct)
- **After**: Both widgets and PF2e show 4725 (synchronized) 
- **Widget sync issue resolved** - GitHub #91 comment bug fixed

## Files Changed
- `src/core/time-converter.ts` - Enhanced `onWorldTimeUpdate()` with system-specific timestamp hook
- `src/integrations/pf2e-integration.ts` - Added `seasons-stars:pf2e:getWorldCreationTimestamp` hook listener

🤖 Generated with [Claude Code](https://claude.ai/code)