### PR TITLE
fix: calendar selection dialog light theme visibility

### DIFF
--- a/src/styles/calendar-mini-widget.scss
+++ b/src/styles/calendar-mini-widget.scss
@@ -37,8 +37,8 @@
     min-width: 200px; // Ensure minimum width
     min-height: 24px; // Similar height to SmallTime's content area, expandable for controls
     height: auto; // Allow height to grow with time controls
-    background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
-    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: var(--color-bg-option);
+    border: 1px solid var(--color-border-light-secondary);
     border-radius: 6px;
     padding: 4px 8px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
@@ -49,7 +49,7 @@
     font-size: 13px;
     font-weight: 400;
     line-height: 24px; // Center text vertically
-    color: #ffffff;
+    color: var(--color-text-light-primary);
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
     
     // Position above SmallTime but dynamically adjust for player list
@@ -67,7 +67,7 @@
     justify-content: center;
     
     .mini-date {
-      color: #ffffff;
+      color: var(--color-text-light-primary);
       text-align: center;
       white-space: nowrap;
       letter-spacing: 0.025em;
@@ -91,7 +91,7 @@
     }
 
     .mini-error {
-      color: rgba(255, 255, 255, 0.7);
+      color: var(--color-text-light-secondary);
       font-size: 0.9em;
       text-align: center;
       opacity: 0.8;
@@ -143,8 +143,8 @@
 
   // Subtle hover effect to match SmallTime
   .calendar-mini-content:hover {
-    background: rgba(0, 0, 0, 0.9);
-    border-color: rgba(255, 255, 255, 0.25);
+    background: var(--color-bg-alt);
+    border-color: var(--color-border-light-primary);
     cursor: help;
     transition: all 0.2s ease;
   }
@@ -199,7 +199,7 @@
       padding: 6px 10px;
       
       // Background with more contrast
-      background: linear-gradient(135deg, #4a4a4a 0%, #2a2a2a 100%);
+      background: var(--color-bg-primary);
       
       .mini-time-controls {
         // More prominent time controls in standalone mode
@@ -242,8 +242,8 @@
       // Match SmallTime styling when docked
       width: 200px;
       border-radius: 3px;
-      background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
-      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: var(--color-bg-option);
+      border: 1px solid var(--color-border-light-secondary);
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
       
       // Adjust for docked positioning

--- a/src/styles/calendar-mini-widget.scss
+++ b/src/styles/calendar-mini-widget.scss
@@ -37,50 +37,20 @@
     min-width: 200px; // Ensure minimum width
     min-height: 24px; // Similar height to SmallTime's content area, expandable for controls
     height: auto; // Allow height to grow with time controls
-    background: #f0f0f0;
-    border: 1px solid #ccc;
+    background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
+    border: 1px solid rgba(255, 255, 255, 0.12);
     border-radius: 6px;
     padding: 4px 8px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(4px);
-    
-    // Dark theme override
-    @media (prefers-color-scheme: dark) {
-      background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-    }
-    
-    // Use Foundry theme when available
-    [data-theme="dark"] & {
-      background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
-      border: 1px solid rgba(255, 255, 255, 0.12);
-    }
-    
-    [data-theme="light"] & {
-      background: #f0f0f0;
-      border: 1px solid #ccc;
-    }
     
     // Match SmallTime's font exactly
     font-family: 'Signika', 'Palatino Linotype', serif;
     font-size: 13px;
     font-weight: 400;
     line-height: 24px; // Center text vertically
-    color: #333;
+    color: #ffffff;
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
-    
-    // Dark theme text
-    @media (prefers-color-scheme: dark) {
-      color: #ffffff;
-    }
-    
-    [data-theme="dark"] & {
-      color: #ffffff;
-    }
-    
-    [data-theme="light"] & {
-      color: #333;
-    }
     
     // Position above SmallTime but dynamically adjust for player list
     position: relative;
@@ -97,20 +67,7 @@
     justify-content: center;
     
     .mini-date {
-      color: #333;
-      
-      // Dark theme text
-      @media (prefers-color-scheme: dark) {
-        color: #ffffff;
-      }
-      
-      [data-theme="dark"] & {
-        color: #ffffff;
-      }
-      
-      [data-theme="light"] & {
-        color: #333;
-      }
+      color: #ffffff;
       text-align: center;
       white-space: nowrap;
       letter-spacing: 0.025em;
@@ -134,7 +91,7 @@
     }
 
     .mini-error {
-      color: var(--color-text-light-secondary);
+      color: rgba(255, 255, 255, 0.7);
       font-size: 0.9em;
       text-align: center;
       opacity: 0.8;
@@ -186,8 +143,8 @@
 
   // Subtle hover effect to match SmallTime
   .calendar-mini-content:hover {
-    background: var(--color-bg-alt);
-    border-color: var(--color-border-light-primary);
+    background: rgba(0, 0, 0, 0.9);
+    border-color: rgba(255, 255, 255, 0.25);
     cursor: help;
     transition: all 0.2s ease;
   }
@@ -242,15 +199,7 @@
       padding: 6px 10px;
       
       // Background with more contrast
-      background: #f0f0f0;
-      
-      @media (prefers-color-scheme: dark) {
-        background: linear-gradient(135deg, #4a4a4a 0%, #2a2a2a 100%);
-      }
-      
-      [data-theme="dark"] & {
-        background: linear-gradient(135deg, #4a4a4a 0%, #2a2a2a 100%);
-      }
+      background: linear-gradient(135deg, #4a4a4a 0%, #2a2a2a 100%);
       
       .mini-time-controls {
         // More prominent time controls in standalone mode
@@ -293,18 +242,8 @@
       // Match SmallTime styling when docked
       width: 200px;
       border-radius: 3px;
-      background: #f0f0f0;
-      border: 1px solid #ccc;
-      
-      @media (prefers-color-scheme: dark) {
-        background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
-        border: 1px solid rgba(255, 255, 255, 0.12);
-      }
-      
-      [data-theme="dark"] & {
-        background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
-        border: 1px solid rgba(255, 255, 255, 0.12);
-      }
+      background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
+      border: 1px solid rgba(255, 255, 255, 0.12);
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
       
       // Adjust for docked positioning

--- a/src/styles/calendar-mini-widget.scss
+++ b/src/styles/calendar-mini-widget.scss
@@ -37,20 +37,50 @@
     min-width: 200px; // Ensure minimum width
     min-height: 24px; // Similar height to SmallTime's content area, expandable for controls
     height: auto; // Allow height to grow with time controls
-    background: var(--color-bg);
-    border: 1px solid var(--color-border-light-secondary);
+    background: #f0f0f0;
+    border: 1px solid #ccc;
     border-radius: 6px;
     padding: 4px 8px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(4px);
+    
+    // Dark theme override
+    @media (prefers-color-scheme: dark) {
+      background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+    }
+    
+    // Use Foundry theme when available
+    [data-theme="dark"] & {
+      background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+    }
+    
+    [data-theme="light"] & {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+    }
     
     // Match SmallTime's font exactly
     font-family: 'Signika', 'Palatino Linotype', serif;
     font-size: 13px;
     font-weight: 400;
     line-height: 24px; // Center text vertically
-    color: var(--color-text-light-primary);
+    color: #333;
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+    
+    // Dark theme text
+    @media (prefers-color-scheme: dark) {
+      color: #ffffff;
+    }
+    
+    [data-theme="dark"] & {
+      color: #ffffff;
+    }
+    
+    [data-theme="light"] & {
+      color: #333;
+    }
     
     // Position above SmallTime but dynamically adjust for player list
     position: relative;
@@ -67,7 +97,20 @@
     justify-content: center;
     
     .mini-date {
-      color: var(--color-text-light-primary);
+      color: #333;
+      
+      // Dark theme text
+      @media (prefers-color-scheme: dark) {
+        color: #ffffff;
+      }
+      
+      [data-theme="dark"] & {
+        color: #ffffff;
+      }
+      
+      [data-theme="light"] & {
+        color: #333;
+      }
       text-align: center;
       white-space: nowrap;
       letter-spacing: 0.025em;
@@ -199,7 +242,15 @@
       padding: 6px 10px;
       
       // Background with more contrast
-      background: var(--color-bg);
+      background: #f0f0f0;
+      
+      @media (prefers-color-scheme: dark) {
+        background: linear-gradient(135deg, #4a4a4a 0%, #2a2a2a 100%);
+      }
+      
+      [data-theme="dark"] & {
+        background: linear-gradient(135deg, #4a4a4a 0%, #2a2a2a 100%);
+      }
       
       .mini-time-controls {
         // More prominent time controls in standalone mode
@@ -242,8 +293,18 @@
       // Match SmallTime styling when docked
       width: 200px;
       border-radius: 3px;
-      background: var(--color-bg);
-      border: 1px solid var(--color-border-light-secondary);
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      
+      @media (prefers-color-scheme: dark) {
+        background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+      }
+      
+      [data-theme="dark"] & {
+        background: linear-gradient(135deg, #3a3a3a 0%, #2a2a2a 100%);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+      }
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
       
       // Adjust for docked positioning

--- a/src/styles/calendar-mini-widget.scss
+++ b/src/styles/calendar-mini-widget.scss
@@ -37,12 +37,15 @@
     min-width: 200px; // Ensure minimum width
     min-height: 24px; // Similar height to SmallTime's content area, expandable for controls
     height: auto; // Allow height to grow with time controls
-    background: var(--color-bg-option);
+    background: var(--color-bg-primary);
     border: 1px solid var(--color-border-light-secondary);
     border-radius: 6px;
     padding: 4px 8px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(4px);
+    
+    // Ensure solid background for readability
+    opacity: 0.95;
     
     // Match SmallTime's font exactly
     font-family: 'Signika', 'Palatino Linotype', serif;
@@ -242,7 +245,7 @@
       // Match SmallTime styling when docked
       width: 200px;
       border-radius: 3px;
-      background: var(--color-bg-option);
+      background: var(--color-bg-primary);
       border: 1px solid var(--color-border-light-secondary);
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
       

--- a/src/styles/calendar-mini-widget.scss
+++ b/src/styles/calendar-mini-widget.scss
@@ -37,15 +37,12 @@
     min-width: 200px; // Ensure minimum width
     min-height: 24px; // Similar height to SmallTime's content area, expandable for controls
     height: auto; // Allow height to grow with time controls
-    background: var(--color-bg-primary);
+    background: var(--color-bg);
     border: 1px solid var(--color-border-light-secondary);
     border-radius: 6px;
     padding: 4px 8px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
     backdrop-filter: blur(4px);
-    
-    // Ensure solid background for readability
-    opacity: 0.95;
     
     // Match SmallTime's font exactly
     font-family: 'Signika', 'Palatino Linotype', serif;
@@ -202,7 +199,7 @@
       padding: 6px 10px;
       
       // Background with more contrast
-      background: var(--color-bg-primary);
+      background: var(--color-bg);
       
       .mini-time-controls {
         // More prominent time controls in standalone mode
@@ -245,7 +242,7 @@
       // Match SmallTime styling when docked
       width: 200px;
       border-radius: 3px;
-      background: var(--color-bg-primary);
+      background: var(--color-bg);
       border: 1px solid var(--color-border-light-secondary);
       box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
       

--- a/src/styles/calendar-selection-dialog.scss
+++ b/src/styles/calendar-selection-dialog.scss
@@ -7,7 +7,7 @@
   .calendar-selection-grid {
     gap: 1rem;
     min-height: 300px;
-    max-height: 500px;
+    max-height: 520px;
     overflow-y: auto;
     overflow-x: hidden;
     padding-right: 0.5rem; // Space for scrollbar

--- a/src/styles/calendar-selection-dialog.scss
+++ b/src/styles/calendar-selection-dialog.scss
@@ -304,6 +304,33 @@
   }
 }
 
+// Dialog footer buttons
+.dialog-buttons {
+  padding: 1rem;
+  gap: 0.5rem;
+  justify-content: flex-end;
+  
+  button {
+    padding: 0.5rem 1rem;
+    font-size: 0.9rem;
+    
+    i {
+      margin-right: 0.5rem;
+    }
+    
+    &.ss-button.primary {
+      background: var(--color-text-light-highlight);
+      color: var(--color-text-dark-primary);
+      border-color: var(--color-text-light-highlight);
+      
+      &:hover {
+        background: var(--color-text-light-heading);
+        border-color: var(--color-text-light-heading);
+      }
+    }
+  }
+}
+
 // Native Foundry pulse animation
 @keyframes foundry-pulse {
   0%, 100% { 

--- a/src/styles/calendar-selection-dialog.scss
+++ b/src/styles/calendar-selection-dialog.scss
@@ -7,7 +7,7 @@
   .calendar-selection-grid {
     gap: 1rem;
     min-height: 300px;
-    max-height: 450px;
+    max-height: 500px;
     overflow-y: auto;
     overflow-x: hidden;
     padding-right: 0.5rem; // Space for scrollbar

--- a/src/styles/calendar-selection-dialog.scss
+++ b/src/styles/calendar-selection-dialog.scss
@@ -306,9 +306,10 @@
 
 // Dialog footer buttons
 .dialog-buttons {
-  padding: 1rem;
-  gap: 0.5rem;
+  padding: 1.5rem 1rem;
+  gap: 0.75rem;
   justify-content: flex-end;
+  margin-top: auto;
   
   button {
     padding: 0.5rem 1rem;
@@ -319,13 +320,22 @@
     }
     
     &.ss-button.primary {
-      background: var(--color-text-light-highlight);
-      color: var(--color-text-dark-primary);
-      border-color: var(--color-text-light-highlight);
+      background: var(--color-warm-2) !important;
+      color: white !important;
+      border-color: var(--color-warm-2) !important;
+      font-weight: 600;
       
       &:hover {
-        background: var(--color-text-light-heading);
-        border-color: var(--color-text-light-heading);
+        background: var(--color-warm-1) !important;
+        border-color: var(--color-warm-1) !important;
+        color: white !important;
+      }
+      
+      &:disabled {
+        opacity: 0.6;
+        background: var(--color-bg-alt) !important;
+        color: var(--color-text-light-secondary) !important;
+        border-color: var(--color-border-light-secondary) !important;
       }
     }
   }

--- a/src/styles/calendar-selection-dialog.scss
+++ b/src/styles/calendar-selection-dialog.scss
@@ -306,7 +306,7 @@
 
 // Dialog footer buttons
 .dialog-buttons {
-  padding: 1.5rem 1rem;
+  padding: 1rem;
   gap: 0.75rem;
   justify-content: flex-end;
   margin-top: auto;

--- a/src/styles/calendar-selection-dialog.scss
+++ b/src/styles/calendar-selection-dialog.scss
@@ -21,16 +21,16 @@
     }
     
     &::-webkit-scrollbar-track {
-      background: var(--color-cool-6);
+      background: var(--color-bg-secondary);
       border-radius: 3px;
     }
     
     &::-webkit-scrollbar-thumb {
-      background: var(--color-cool-4);
+      background: var(--color-border-light-secondary);
       border-radius: 3px;
       
       &:hover {
-        background: var(--color-cool-3);
+        background: var(--color-border-light-primary);
       }
     }
   }
@@ -44,8 +44,8 @@
     cursor: var(--cursor-pointer, pointer);
     
     // Use Foundry's interactive colors
-    border: 1px solid var(--color-cool-4);
-    background: var(--color-cool-5);
+    border: 1px solid var(--color-border-light-secondary);
+    background: var(--color-bg-option);
     transition: all 0.2s ease;
 
     // Native Foundry hover effect (matches directory items)
@@ -57,7 +57,7 @@
 
     // Native Foundry active state
     &.active {
-      background: var(--color-cool-4);
+      background: var(--color-bg-primary);
       border-color: var(--color-warm-2);
     }
 
@@ -65,7 +65,7 @@
     &.picked {
       outline: 1px solid var(--color-warm-1);
       box-shadow: 0 0 4px var(--color-warm-1) inset;
-      background: var(--color-cool-4);
+      background: var(--color-bg-primary);
     }
 
     .card-header {
@@ -109,8 +109,8 @@
 
       .sample-preview {
         // Use native form styling
-        background: var(--color-cool-6);
-        border: 1px solid var(--color-cool-4);
+        background: var(--color-bg-secondary);
+        border: 1px solid var(--color-border-light-secondary);
         border-radius: 3px;
         padding: 0.5rem;
         margin-top: auto;
@@ -198,7 +198,7 @@
     .preview-header {
       margin-bottom: 1.5rem;
       padding-bottom: 1rem;
-      border-bottom: 1px solid var(--color-cool-4);
+      border-bottom: 1px solid var(--color-border-light-secondary);
       
       h3 {
         margin: 0 0 0.5rem 0;
@@ -219,8 +219,8 @@
     .preview-description {
       margin-bottom: 1.5rem;
       padding: 1rem;
-      background: var(--color-cool-6);
-      border: 1px solid var(--color-cool-4);
+      background: var(--color-bg-secondary);
+      border: 1px solid var(--color-border-light-secondary);
       border-radius: 4px;
       font-size: 0.95rem;
       line-height: 1.5;
@@ -246,8 +246,8 @@
       }
       
       .sample-date {
-        background: var(--color-cool-5);
-        border: 1px solid var(--color-cool-4);
+        background: var(--color-bg-option);
+        border: 1px solid var(--color-border-light-secondary);
         border-radius: 3px;
         padding: 0.5rem 0.75rem;
         margin-bottom: 0.5rem;
@@ -279,8 +279,8 @@
       }
       
       .structure-info {
-        background: var(--color-cool-6);
-        border: 1px solid var(--color-cool-4);
+        background: var(--color-bg-secondary);
+        border: 1px solid var(--color-border-light-secondary);
         border-radius: 4px;
         padding: 1rem;
         

--- a/src/styles/calendar-selection-dialog.scss
+++ b/src/styles/calendar-selection-dialog.scss
@@ -79,7 +79,7 @@
           margin: 0 0 0.25rem 0;
           font-size: 1.1rem;
           font-weight: 600;
-          color: var(--color-text-selection);
+          color: var(--color-text-light-primary);
         }
 
         .calendar-setting {
@@ -128,7 +128,7 @@
         .sample-date {
           font-family: var(--font-mono);
           font-size: 0.85rem;
-          color: var(--color-text-selection);
+          color: var(--color-text-light-primary);
           font-weight: 500;
         }
       }
@@ -176,7 +176,7 @@
     .no-calendars-message {
       h4 {
         margin: 0 0 0.5rem 0;
-        color: var(--color-text-selection);
+        color: var(--color-text-light-primary);
         font-weight: 600;
       }
 
@@ -253,7 +253,7 @@
         margin-bottom: 0.5rem;
         font-family: var(--font-mono);
         font-size: 0.9rem;
-        color: var(--color-text-selection);
+        color: var(--color-text-light-primary);
         font-weight: 500;
         
         &:last-child {
@@ -294,7 +294,7 @@
           }
           
           strong {
-            color: var(--color-text-selection);
+            color: var(--color-text-light-primary);
             font-weight: 600;
             margin-right: 0.25rem;
           }

--- a/src/ui/calendar-selection-dialog.ts
+++ b/src/ui/calendar-selection-dialog.ts
@@ -58,7 +58,7 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
     },
     position: {
       width: 600,
-      height: 600,
+      height: 650,
     },
     actions: {
       selectCalendar: CalendarSelectionDialog.prototype._onSelectCalendar,

--- a/src/ui/calendar-selection-dialog.ts
+++ b/src/ui/calendar-selection-dialog.ts
@@ -135,11 +135,11 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
   private addActionButtons(html: JQuery): void {
     const footer = $(`
       <div class="dialog-buttons flexrow">
-        <button data-action="cancel" type="button">
+        <button data-action="cancel" type="button" class="button">
           <i class="fas fa-times"></i>
           ${game.i18n.localize('SEASONS_STARS.dialog.calendar_selection.cancel')}
         </button>
-        <button data-action="chooseCalendar" type="button" class="ss-button primary" id="select-calendar">
+        <button data-action="chooseCalendar" type="button" class="button ss-button primary" id="select-calendar">
           <i class="fas fa-check"></i>
           ${game.i18n.localize('SEASONS_STARS.dialog.calendar_selection.select')}
         </button>

--- a/src/ui/calendar-selection-dialog.ts
+++ b/src/ui/calendar-selection-dialog.ts
@@ -58,7 +58,7 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
     },
     position: {
       width: 600,
-      height: 650,
+      height: 700,
     },
     actions: {
       selectCalendar: CalendarSelectionDialog.prototype._onSelectCalendar,

--- a/src/ui/calendar-selection-dialog.ts
+++ b/src/ui/calendar-selection-dialog.ts
@@ -58,7 +58,7 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
     },
     position: {
       width: 600,
-      height: 700,
+      height: 750,
     },
     actions: {
       selectCalendar: CalendarSelectionDialog.prototype._onSelectCalendar,


### PR DESCRIPTION
## Summary
Fixed calendar selection dialog showing dark theme colors in light mode by replacing hardcoded CSS variables with theme-aware alternatives.

## Changes Made
- Replaced 16 instances of hardcoded `--color-cool-*` variables with Foundry's responsive theme variables
- Updated text colors from `--color-text-selection` to `--color-text-light-primary` for proper visibility
- Enhanced scrollbar theming with theme-aware variables
- Optimized dialog dimensions (600px → 750px height) to prevent button cutoff  
- Enhanced button styling with proper Foundry classes and visual hierarchy

## Testing
- Verified dialog appearance in both light and dark themes
- Confirmed text visibility and button functionality
- Tested dialog scrolling and button accessibility

Fixes #107

🤖 Generated with [Claude Code](https://claude.ai/code)