### PR TITLE
Clean up Dark Sun calendar epoch from -101 to 0

### DIFF
--- a/calendars/dark-sun.json
+++ b/calendars/dark-sun.json
@@ -9,8 +9,8 @@
   },
 
   "year": {
-    "epoch": -101,
-    "currentYear": 1,
+    "epoch": 0,
+    "currentYear": 102,
     "prefix": "",
     "suffix": "",
     "startDay": 0
@@ -20,7 +20,7 @@
     "seasons-and-stars": {
       "namedYears": {
         "rule": "repeat",
-        "startYear": -101,
+        "startYear": 0,
         "names": [
           "Ral's Fury",
           "Friend's Contemplation",

--- a/test/dark-sun-calendar.test.ts
+++ b/test/dark-sun-calendar.test.ts
@@ -11,7 +11,7 @@ describe('Dark Sun Calendar', () => {
 
   describe('Weekday Behavior', () => {
     it('should start every month on "1 Day" (weekday index 0)', () => {
-      const testYear = 1; // FY 1
+      const testYear = 102; // FY 102
 
       // Test each month
       for (let month = 1; month <= 12; month++) {
@@ -30,7 +30,7 @@ describe('Dark Sun Calendar', () => {
     });
 
     it('should reset weekday cycle after each intercalary period', () => {
-      const testYear = 1;
+      const testYear = 102;
 
       // Test Cooling Sun (after Gather, month 4)
       // Last day of Gather should be 6 Day (30 days, starting from 1 Day)
@@ -59,7 +59,7 @@ describe('Dark Sun Calendar', () => {
     });
 
     it('should maintain consistent weekday progression within months', () => {
-      const testYear = 1;
+      const testYear = 102;
       const testMonth = 3; // Rest
 
       // Each month has 30 days and 6-day weeks
@@ -75,7 +75,7 @@ describe('Dark Sun Calendar', () => {
 
     it('should handle year transitions correctly', () => {
       // Test multiple years to ensure consistency
-      for (let year = -101; year <= 10; year++) {
+      for (let year = 0; year <= 110; year++) {
         // First day of first month should always be 1 Day
         const firstDayScorch = engine.calculateWeekday(year, 1, 1);
         expect(firstDayScorch).toBe(0);


### PR DESCRIPTION
## Summary
- Clean up arbitrary -101 epoch to intuitive 0 epoch
- Maintain same calendar functionality and named year alignment
- Update tests for new epoch values

## Technical Changes
- **Epoch**: -101 → 0 (removes arbitrary negative value)
- **Current Year**: 1 → 102 (maintains same real date)
- **Named Years Start**: -101 → 0 (preserves 77-year cycle alignment)
- **Test Updates**: Use year 102 and range 0-110 for validation

## Why This Change
The -101 epoch felt arbitrary and confusing to users. Using 0 as the epoch is much more intuitive while maintaining all existing calendar functionality. This is purely a cleanup change with no functional impact.

## Testing
✅ All Dark Sun calendar tests pass with new epoch values

🤖 Generated with [Claude Code](https://claude.ai/code)