### PR TITLE
chore: fix release-please configuration for monorepo

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/core": "0.7.0",
-  "packages/fantasy-pack": "1.0.0",
-  "packages/scifi-pack": "1.0.0"
+  "packages/fantasy-pack": "0.0.0",
+  "packages/scifi-pack": "0.0.0"
 }

--- a/packages/fantasy-pack/package.json
+++ b/packages/fantasy-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seasons-and-stars-fantasy",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Fantasy RPG calendar collection for Seasons & Stars",
   "type": "module",
   "calendar-pack": {

--- a/packages/scifi-pack/package.json
+++ b/packages/scifi-pack/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seasons-and-stars-scifi",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Science fiction calendar collection for Seasons & Stars",
   "type": "module",
   "calendar-pack": {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,13 @@
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
-      "extra-files": ["module.json"]
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "module.json",
+          "jsonpath": "$.version"
+        }
+      ]
     },
     "packages/fantasy-pack": {
       "package-name": "seasons-and-stars-fantasy",
@@ -16,7 +22,13 @@
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
-      "extra-files": ["module.json"]
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "module.json",
+          "jsonpath": "$.version"
+        }
+      ]
     },
     "packages/scifi-pack": {
       "package-name": "seasons-and-stars-scifi",
@@ -25,7 +37,13 @@
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
       "prerelease": false,
-      "extra-files": ["module.json"]
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "module.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary
- Reset unreleased pack versions from 1.0.0 to 0.0.0 since they haven't been released yet
- Add proper JSON path configuration for `module.json` version updates using `jsonpath: "$.version"`
- Update `.release-please-manifest.json` to reflect correct package versions
- Ensure consistent version synchronization between `package.json` and `module.json` files

## Changes Made
- **Fantasy Pack & Sci-Fi Pack**: Reset versions to `0.0.0` (appropriate for unreleased packages)
- **Release Config**: Added proper `extra-files` configuration with JSON path syntax
- **Manifest**: Updated to match actual package versions

## Why This Fixes the Issue
The previous configuration was causing v0.2.4 version regressions because:
1. Unreleased packages had premature 1.0.0 versions
2. `extra-files` configuration was using simple string format instead of proper JSON path
3. Version misalignment between different configuration files

This ensures release-please will now correctly:
- Create proper version tags (no more v0.2.4 regressions)
- Update both `package.json` and `module.json` files during releases
- Generate appropriate monorepo tags in `package-name@version` format

🤖 Generated with [Claude Code](https://claude.ai/code)