### PR TITLE
fix: hide calendar selector for non-GM users

### DIFF
--- a/packages/core/src/ui/calendar-widget.ts
+++ b/packages/core/src/ui/calendar-widget.ts
@@ -178,6 +178,9 @@ export class CalendarWidget extends foundry.applications.api.HandlebarsApplicati
    */
   async _onOpenCalendarSelection(event: Event, _target: HTMLElement): Promise<void> {
     event.preventDefault();
+    if (!game.user?.isGM) {
+      return;
+    }
     CalendarSelectionDialog.show();
   }
 

--- a/packages/core/templates/calendar-widget.hbs
+++ b/packages/core/templates/calendar-widget.hbs
@@ -8,10 +8,10 @@
   {{else}}
     {{!-- Calendar Header --}}
     <div class="calendar-header">
-      <div class="calendar-title clickable" data-action="openCalendarSelection" title="Click to change calendar system">
+      <div class="calendar-title {{#if isGM}}clickable{{/if}}" {{#if isGM}}data-action="openCalendarSelection" title="Click to change calendar system"{{/if}}>
         <i class="fas fa-calendar-alt"></i>
         <span>{{calendar.label}}</span>
-        <i class="fas fa-chevron-down dropdown-icon"></i>
+        {{#if isGM}}<i class="fas fa-chevron-down dropdown-icon"></i>{{/if}}
       </div>
       <div class="widget-switching-controls">
         <button type="button" class="widget-switch-btn" data-action="switchToMini" title="Switch to Mini Widget">
@@ -21,7 +21,9 @@
           <i class="fas fa-th"></i>
         </button>
       </div>
-      <div class="calendar-hint">Click above to change calendar</div>
+      {{#if isGM}}
+        <div class="calendar-hint">Click above to change calendar</div>
+      {{/if}}
       {{#if calendar.setting}}
         <div class="calendar-setting">{{calendar.setting}}</div>
       {{/if}}

--- a/packages/core/test/calendar-widget-gm-permissions.test.ts
+++ b/packages/core/test/calendar-widget-gm-permissions.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for CalendarWidget GM-specific behaviors and template access
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Handlebars from 'handlebars';
+import path from 'path';
+import fs from 'fs';
+import { CalendarWidget } from '../src/ui/calendar-widget';
+import { CalendarSelectionDialog } from '../src/ui/calendar-selection-dialog';
+import { CalendarDate } from '../src/core/calendar-date';
+import type { SeasonsStarsCalendar } from '../src/types/calendar';
+import { setupFoundryEnvironment } from './setup';
+
+// Mock TimeAdvancementService to avoid initialization logic
+vi.mock('../src/core/time-advancement-service', () => ({
+  TimeAdvancementService: {
+    getInstance: vi.fn(() => ({ shouldShowPauseButton: false })),
+  },
+}));
+
+// Use real Handlebars for template rendering
+(globalThis as any).Handlebars = Handlebars;
+
+describe('CalendarWidget GM permissions', () => {
+  let widget: CalendarWidget;
+  let template: Handlebars.TemplateDelegate;
+  let mockCalendar: SeasonsStarsCalendar;
+  let mockDate: CalendarDate;
+
+  beforeEach(() => {
+    setupFoundryEnvironment();
+    vi.restoreAllMocks();
+
+    // Stub SmallTime detection to disable quick time controls in template
+    vi.spyOn(CalendarWidget.prototype as any, 'detectSmallTime').mockReturnValue(true);
+
+    // Load and compile the widget template
+    const templatePath = path.join(__dirname, '../templates/calendar-widget.hbs');
+    const source = fs.readFileSync(templatePath, 'utf8');
+    template = Handlebars.compile(source);
+
+    // Minimal calendar and date setup
+    mockCalendar = {
+      id: 'test',
+      name: 'Test Calendar',
+      label: 'Test Calendar',
+      months: [{ name: 'January', days: 31 }],
+      weekdays: [{ name: 'Monday', abbreviation: 'Mon' }],
+      yearLength: 365,
+      weekLength: 7,
+      epoch: { year: 1, month: 1, day: 1 },
+      translations: {
+        en: {
+          label: 'Test Calendar',
+          description: 'A test calendar',
+          setting: 'Test setting',
+        },
+      },
+    } as SeasonsStarsCalendar;
+
+    mockDate = new CalendarDate(
+      {
+        year: 2024,
+        month: 1,
+        day: 1,
+        weekday: 0,
+        time: { hour: 12, minute: 0, second: 0 },
+      },
+      mockCalendar
+    );
+
+    // Configure game globals used by the widget
+    game.seasonsStars = {
+      manager: {
+        getActiveCalendar: vi.fn(() => mockCalendar),
+        getCurrentDate: vi.fn(() => mockDate),
+      },
+    } as any;
+
+    (game.settings.get as any) = vi.fn((module: string, key: string) => {
+      if (key === 'timeAdvancementRatio') return 1.0;
+      if (key === 'pauseOnCombat') return true;
+      if (key === 'resumeAfterCombat') return false;
+      if (key === 'alwaysShowQuickTimeButtons') return false;
+      return undefined;
+    });
+
+    widget = new CalendarWidget();
+  });
+
+  it('prevents non-GMs from opening the calendar selection dialog', async () => {
+    game.user = { isGM: false } as any;
+    const showSpy = vi.spyOn(CalendarSelectionDialog, 'show').mockResolvedValue();
+
+    const event = new Event('click');
+    await widget._onOpenCalendarSelection(event, document.createElement('div'));
+
+    expect(showSpy).not.toHaveBeenCalled();
+  });
+
+  it('renders calendar selector only for GMs', async () => {
+    // GM view
+    game.user = { isGM: true } as any;
+    let context = await widget._prepareContext();
+    expect(context.isGM).toBe(true);
+    let html = template(context);
+    expect(html).toContain('data-action="openCalendarSelection"');
+    expect(html).toContain('calendar-hint');
+
+    // Player view
+    game.user = { isGM: false } as any;
+    context = await widget._prepareContext();
+    expect(context.isGM).toBe(false);
+    html = template(context);
+    expect(html).not.toContain('data-action="openCalendarSelection"');
+    expect(html).not.toContain('calendar-hint');
+  });
+});


### PR DESCRIPTION
## Summary
- prevent non-GM users from opening the calendar selection dialog
- hide calendar selector UI and hint from players
- add tests ensuring calendar selector only renders for GMs and that `isGM` is passed to the template

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf8e29c9a48327aa6166b07b4654d2