### PR TITLE
chore: clean up test logging and tighten widget types

### DIFF
--- a/packages/core/src/types/foundry-extensions.d.ts
+++ b/packages/core/src/types/foundry-extensions.d.ts
@@ -19,8 +19,8 @@ declare global {
     ready: boolean;
     seasonsStars?: {
       api?: SeasonsStarsAPI;
-      manager?: unknown; // CalendarManager interface
-      notes?: unknown; // NotesManager interface
+      manager?: CalendarManagerInterface; // CalendarManager interface
+      notes?: NotesManagerInterface; // NotesManager interface
       categories?: unknown; // Note categories management
       integration?: SeasonsStarsIntegration | null;
       compatibilityManager?: unknown; // Expose for debugging and external access
@@ -34,20 +34,21 @@ declare global {
   interface Window {
     SeasonsStars?: {
       api: SeasonsStarsAPI;
-      manager: unknown;
-      notes: unknown;
+      manager: CalendarManagerInterface;
+      notes: NotesManagerInterface;
       integration: SeasonsStarsIntegration | null;
       CalendarWidget?: unknown;
       CalendarMiniWidget?: unknown;
       CalendarGridWidget?: unknown;
       CalendarSelectionDialog?: unknown;
       NoteEditingDialog?: unknown;
+      [key: string]: unknown;
     };
   }
 
   interface Combat {
     id: string;
-    [key: string]: any;
+    [key: string]: unknown;
   }
 }
 
@@ -128,28 +129,28 @@ export interface CalendarEngineInterface {
   getMonthLength(month: number, year: number): number;
   dateToWorldTime(date: CalendarDate, worldCreationTimestamp?: number): number;
   worldTimeToDate(timestamp: number, worldCreationTimestamp?: number): CalendarDate;
-  getIntercalaryDaysAfterMonth(month: number, year: number): any[];
+  getIntercalaryDaysAfterMonth(month: number, year: number): unknown[];
   addMonths(date: CalendarDate, months: number): CalendarDate;
   addYears(date: CalendarDate, years: number): CalendarDate;
 }
 
 // Notes Manager interface for type safety
 export interface NotesManagerInterface {
-  createNote(data: any): Promise<JournalEntry>;
-  updateNote(noteId: string, data: any): Promise<JournalEntry>;
+  createNote(data: unknown): Promise<JournalEntry>;
+  updateNote(noteId: string, data: unknown): Promise<JournalEntry>;
   deleteNote(noteId: string): Promise<void>;
   getNote(noteId: string): Promise<JournalEntry | null>;
   getNotesForDate(date: CalendarDate): Promise<JournalEntry[]>;
   getNotesForDateRange(start: CalendarDate, end: CalendarDate): Promise<JournalEntry[]>;
-  setNoteModuleData(noteId: string, moduleId: string, data: any): Promise<void>;
-  getNoteModuleData(noteId: string, moduleId: string): any;
+  setNoteModuleData(noteId: string, moduleId: string, data: unknown): Promise<void>;
+  getNoteModuleData(noteId: string, moduleId: string): unknown;
   canCreateNote(): boolean;
-  getCategories(): any;
+  getCategories(): unknown;
   getPredefinedTags(): string[];
   parseTagString(tags: string): string[];
   validateTags(tags: string[]): boolean;
-  getDefaultCategory(): any;
-  getCategory(categoryId: string): any;
+  getDefaultCategory(): unknown;
+  getCategory(categoryId: string): unknown;
   getAllNotes(): JournalEntry[];
   storage: {
     findNotesByDateSync(date: CalendarDate): JournalEntry[];

--- a/packages/core/src/types/widget-types.d.ts
+++ b/packages/core/src/types/widget-types.d.ts
@@ -47,7 +47,7 @@ export interface GridWidgetContext extends BaseWidgetContext {
   monthDescription?: string;
   yearDisplay: string;
   weekdays: WeekdayInfo[];
-  notesForDays: Record<string, any[]>; // Date string -> notes array
+  notesForDays: Record<string, unknown[]>; // Date string -> notes array
 }
 
 // Widget render options
@@ -101,7 +101,7 @@ export interface SidebarButton {
   name: string;
   icon: string;
   tooltip: string;
-  callback: Function;
+  callback: () => void;
 }
 
 // Scene control types

--- a/packages/core/src/ui/base-widget-manager.ts
+++ b/packages/core/src/ui/base-widget-manager.ts
@@ -6,49 +6,70 @@
 import { Logger } from '../core/logger';
 import type { SidebarButton } from '../types/widget-types';
 
+interface RenderableWidget {
+  rendered: boolean;
+  render(force?: boolean): void;
+  bringToTop?(): void;
+  close(): void;
+}
+
+function isRenderableWidget(obj: unknown): obj is RenderableWidget {
+  if (!obj || typeof obj !== 'object') return false;
+  const candidate = obj as {
+    rendered?: unknown;
+    render?: unknown;
+    close?: unknown;
+  };
+  return (
+    typeof candidate.rendered === 'boolean' &&
+    typeof candidate.render === 'function' &&
+    typeof candidate.close === 'function'
+  );
+}
+
 /**
  * Base widget instance management (without generics for static compatibility)
  */
 export class WidgetInstanceManager {
-  protected static activeInstance: unknown = null;
+  protected static activeInstance: RenderableWidget | null = null;
 
   /**
    * Get the active instance of this widget
    */
-  static getInstance(): unknown {
+  static getInstance(): RenderableWidget | null {
     return this.activeInstance;
   }
 
   /**
    * Show the widget
    */
-  static show(): void {
+  static show(this: { new (): RenderableWidget; activeInstance: RenderableWidget | null }): void {
     if (this.activeInstance) {
-      if (!(this.activeInstance as any).rendered) {
-        (this.activeInstance as any).render(true);
+      if (!this.activeInstance.rendered) {
+        this.activeInstance.render(true);
       } else {
-        (this.activeInstance as any).bringToTop();
+        this.activeInstance.bringToTop?.();
       }
     } else {
-      this.activeInstance = new (this as any)();
-      (this.activeInstance as any).render(true);
+      this.activeInstance = new this();
+      this.activeInstance.render(true);
     }
   }
 
   /**
    * Hide the widget
    */
-  static hide(): void {
-    if ((this.activeInstance as any)?.rendered) {
-      (this.activeInstance as any).close();
+  static hide(this: { activeInstance: RenderableWidget | null }): void {
+    if (this.activeInstance?.rendered) {
+      this.activeInstance.close();
     }
   }
 
   /**
    * Toggle the widget visibility
    */
-  static toggle(): void {
-    if ((this.activeInstance as any)?.rendered) {
+  static toggle(this: { new (): RenderableWidget; activeInstance: RenderableWidget | null }): void {
+    if (this.activeInstance?.rendered) {
       this.hide();
     } else {
       this.show();
@@ -58,19 +79,17 @@ export class WidgetInstanceManager {
   /**
    * Register hooks for automatic updates
    */
-  static registerHooks(): void {
+  static registerHooks(this: { activeInstance: RenderableWidget | null }): void {
     // Use arrow function to maintain proper 'this' context
     Hooks.on('seasons-stars:dateChanged', () => {
-      const instance = this.activeInstance as unknown;
-      if (instance && (instance as any)?.rendered) {
-        (instance as any).render();
+      if (this.activeInstance?.rendered) {
+        this.activeInstance.render();
       }
     });
 
     Hooks.on('seasons-stars:calendarChanged', () => {
-      const instance = this.activeInstance as unknown;
-      if (instance && (instance as any)?.rendered) {
-        (instance as any).render();
+      if (this.activeInstance?.rendered) {
+        this.activeInstance.render();
       }
     });
   }
@@ -85,7 +104,7 @@ export class SidebarButtonManager {
   /**
    * Add a sidebar button
    */
-  addSidebarButton(name: string, icon: string, tooltip: string, callback: Function): void {
+  addSidebarButton(name: string, icon: string, tooltip: string, callback: () => void): void {
     // Check if button already exists
     const existingButton = this.sidebarButtons.find(btn => btn.name === name);
     if (existingButton) {
@@ -98,8 +117,8 @@ export class SidebarButtonManager {
     Logger.debug(`Added sidebar button "${name}"`);
 
     // Trigger re-render if widget is already rendered
-    if ((this as unknown as { rendered: boolean }).rendered) {
-      (this as unknown as { render: () => void }).render();
+    if (isRenderableWidget(this) && this.rendered) {
+      this.render();
     }
   }
 
@@ -113,8 +132,8 @@ export class SidebarButtonManager {
       Logger.debug(`Removed sidebar button "${name}"`);
 
       // Trigger re-render if widget is already rendered
-      if ((this as unknown as { rendered: boolean }).rendered) {
-        (this as unknown as { render: () => void }).render();
+      if (isRenderableWidget(this) && this.rendered) {
+        this.render();
       }
     }
   }
@@ -140,8 +159,8 @@ export class SidebarButtonManager {
     this.sidebarButtons = [];
     Logger.debug('Cleared all sidebar buttons');
 
-    if ((this as unknown as { rendered: boolean }).rendered) {
-      (this as unknown as { render: () => void }).render();
+    if (isRenderableWidget(this) && this.rendered) {
+      this.render();
     }
   }
 }

--- a/packages/core/src/ui/scene-controls.ts
+++ b/packages/core/src/ui/scene-controls.ts
@@ -4,7 +4,7 @@
 
 import { CalendarWidgetManager } from './widget-manager';
 import { Logger } from '../core/logger';
-import type { CalendarManagerInterface } from '../types/foundry-extensions';
+import { isCalendarManager } from '../types/foundry-extensions';
 import type { SceneControl } from '../types/widget-types';
 
 export class SeasonsStarsSceneControls {
@@ -42,7 +42,7 @@ export class SeasonsStarsSceneControls {
           name: 'seasons-stars-widget',
           title: 'SEASONS_STARS.calendar.toggle_calendar',
           icon: 'fas fa-calendar-alt',
-          onChange: () => SeasonsStarsSceneControls.toggleDefaultWidget(),
+          onChange: (): void => SeasonsStarsSceneControls.toggleDefaultWidget(),
           button: true,
         };
 
@@ -175,72 +175,73 @@ export class SeasonsStarsSceneControls {
    */
   static registerMacros(): void {
     // Extend the existing SeasonsStars object with macro functions
-    if (!(window as any).SeasonsStars) {
-      (window as any).SeasonsStars = {};
+    if (!window.SeasonsStars) {
+      window.SeasonsStars = {};
+    }
+
+    // Helper interface for legacy mini widget positioning
+    interface MiniWidgetPositions {
+      positionAboveSmallTime?: () => void;
+      positionBelowSmallTime?: () => void;
+      positionBesideSmallTime?: () => void;
     }
 
     // Add macro functions to the existing object
-    Object.assign((window as any).SeasonsStars, {
+    Object.assign(window.SeasonsStars, {
       // Widget controls - respect default widget setting
-      showWidget: () => SeasonsStarsSceneControls.showDefaultWidget(),
-      hideWidget: () => SeasonsStarsSceneControls.hideDefaultWidget(),
-      toggleWidget: () => SeasonsStarsSceneControls.toggleDefaultWidget(),
+      showWidget: (): void => SeasonsStarsSceneControls.showDefaultWidget(),
+      hideWidget: (): void => SeasonsStarsSceneControls.hideDefaultWidget(),
+      toggleWidget: (): void => SeasonsStarsSceneControls.toggleDefaultWidget(),
 
       // Specific widget controls (for advanced users who want to override default)
-      showMainWidget: () => CalendarWidgetManager.showWidget('main'),
-      hideMainWidget: () => CalendarWidgetManager.hideWidget('main'),
-      toggleMainWidget: () => CalendarWidgetManager.toggleWidget('main'),
-      showMiniWidget: () => CalendarWidgetManager.showWidget('mini'),
-      hideMiniWidget: () => CalendarWidgetManager.hideWidget('mini'),
-      toggleMiniWidget: () => CalendarWidgetManager.toggleWidget('mini'),
-      showGridWidget: () => CalendarWidgetManager.showWidget('grid'),
-      hideGridWidget: () => CalendarWidgetManager.hideWidget('grid'),
-      toggleGridWidget: () => CalendarWidgetManager.toggleWidget('grid'),
+      showMainWidget: (): void => CalendarWidgetManager.showWidget('main'),
+      hideMainWidget: (): void => CalendarWidgetManager.hideWidget('main'),
+      toggleMainWidget: (): void => CalendarWidgetManager.toggleWidget('main'),
+      showMiniWidget: (): void => CalendarWidgetManager.showWidget('mini'),
+      hideMiniWidget: (): void => CalendarWidgetManager.hideWidget('mini'),
+      toggleMiniWidget: (): void => CalendarWidgetManager.toggleWidget('mini'),
+      showGridWidget: (): void => CalendarWidgetManager.showWidget('grid'),
+      hideGridWidget: (): void => CalendarWidgetManager.hideWidget('grid'),
+      toggleGridWidget: (): void => CalendarWidgetManager.toggleWidget('grid'),
 
       // Mini widget positioning (legacy support)
-      positionMiniAboveSmallTime: () => {
-        const miniWidget = CalendarWidgetManager.getWidgetInstance('mini');
-        if (miniWidget && typeof miniWidget.positionAboveSmallTime === 'function') {
-          miniWidget.positionAboveSmallTime();
-        }
+      positionMiniAboveSmallTime: (): void => {
+        const miniWidget = CalendarWidgetManager.getWidgetInstance<MiniWidgetPositions>('mini');
+        miniWidget?.positionAboveSmallTime?.();
       },
-      positionMiniBelowSmallTime: () => {
-        const miniWidget = CalendarWidgetManager.getWidgetInstance('mini');
-        if (miniWidget && typeof miniWidget.positionBelowSmallTime === 'function') {
-          miniWidget.positionBelowSmallTime();
-        }
+      positionMiniBelowSmallTime: (): void => {
+        const miniWidget = CalendarWidgetManager.getWidgetInstance<MiniWidgetPositions>('mini');
+        miniWidget?.positionBelowSmallTime?.();
       },
-      positionMiniBesideSmallTime: () => {
-        const miniWidget = CalendarWidgetManager.getWidgetInstance('mini');
-        if (miniWidget && typeof miniWidget.positionBesideSmallTime === 'function') {
-          miniWidget.positionBesideSmallTime();
-        }
+      positionMiniBesideSmallTime: (): void => {
+        const miniWidget = CalendarWidgetManager.getWidgetInstance<MiniWidgetPositions>('mini');
+        miniWidget?.positionBesideSmallTime?.();
       },
 
       // Time advancement functions for macros
       advanceMinutes: async (minutes: number) => {
-        const manager = game.seasonsStars?.manager as CalendarManagerInterface;
-        if (manager && manager.advanceMinutes) await manager.advanceMinutes(minutes);
+        const manager = game.seasonsStars?.manager;
+        if (isCalendarManager(manager)) await manager.advanceMinutes(minutes);
       },
       advanceHours: async (hours: number) => {
-        const manager = game.seasonsStars?.manager as CalendarManagerInterface;
-        if (manager && manager.advanceHours) await manager.advanceHours(hours);
+        const manager = game.seasonsStars?.manager;
+        if (isCalendarManager(manager)) await manager.advanceHours(hours);
       },
       advanceDays: async (days: number) => {
-        const manager = game.seasonsStars?.manager as CalendarManagerInterface;
-        if (manager && manager.advanceDays) await manager.advanceDays(days);
+        const manager = game.seasonsStars?.manager;
+        if (isCalendarManager(manager)) await manager.advanceDays(days);
       },
       advanceWeeks: async (weeks: number) => {
-        const manager = game.seasonsStars?.manager as CalendarManagerInterface;
-        if (manager && manager.advanceWeeks) await manager.advanceWeeks(weeks);
+        const manager = game.seasonsStars?.manager;
+        if (isCalendarManager(manager)) await manager.advanceWeeks(weeks);
       },
       advanceMonths: async (months: number) => {
-        const manager = game.seasonsStars?.manager as CalendarManagerInterface;
-        if (manager && manager.advanceMonths) await manager.advanceMonths(months);
+        const manager = game.seasonsStars?.manager;
+        if (isCalendarManager(manager)) await manager.advanceMonths(months);
       },
       advanceYears: async (years: number) => {
-        const manager = game.seasonsStars?.manager as CalendarManagerInterface;
-        if (manager && manager.advanceYears) await manager.advanceYears(years);
+        const manager = game.seasonsStars?.manager;
+        if (isCalendarManager(manager)) await manager.advanceYears(years);
       },
     });
 

--- a/packages/core/src/ui/widget-manager.ts
+++ b/packages/core/src/ui/widget-manager.ts
@@ -9,11 +9,11 @@ import { Logger } from '../core/logger';
 
 export type WidgetType = 'main' | 'mini' | 'grid';
 
-export interface WidgetInstance {
+export interface WidgetInstance<T = unknown> {
   show(): Promise<void>;
   hide(): Promise<void>;
   toggle(): Promise<void>;
-  getInstance(): any;
+  getInstance(): T;
   isVisible(): boolean;
 }
 
@@ -143,9 +143,9 @@ export class CalendarWidgetManager {
   /**
    * Get the actual widget instance for direct access
    */
-  static getWidgetInstance(type: WidgetType): any {
+  static getWidgetInstance<T = unknown>(type: WidgetType): T | null {
     const widget = this.getWidget(type);
-    return widget ? widget.getInstance() : null;
+    return widget ? (widget.getInstance() as T) : null;
   }
 
   /**
@@ -189,9 +189,9 @@ export class CalendarWidgetManager {
 /**
  * Widget wrapper class to make any widget compatible with the manager
  */
-export class WidgetWrapper implements WidgetInstance {
+export class WidgetWrapper<T extends Record<string, unknown>> implements WidgetInstance<T> {
   constructor(
-    private widget: any,
+    private widget: T,
     private showMethod: string = 'render',
     private hideMethod: string = 'close',
     private toggleMethod: string = 'toggle',
@@ -200,20 +200,23 @@ export class WidgetWrapper implements WidgetInstance {
   ) {}
 
   async show(): Promise<void> {
-    if (this.widget && typeof this.widget[this.showMethod] === 'function') {
-      await this.widget[this.showMethod]();
+    const fn = (this.widget as Record<string, unknown>)[this.showMethod];
+    if (typeof fn === 'function') {
+      await (fn as () => Promise<void>).call(this.widget);
     }
   }
 
   async hide(): Promise<void> {
-    if (this.widget && typeof this.widget[this.hideMethod] === 'function') {
-      await this.widget[this.hideMethod]();
+    const fn = (this.widget as Record<string, unknown>)[this.hideMethod];
+    if (typeof fn === 'function') {
+      await (fn as () => Promise<void>).call(this.widget);
     }
   }
 
   async toggle(): Promise<void> {
-    if (this.widget && typeof this.widget[this.toggleMethod] === 'function') {
-      await this.widget[this.toggleMethod]();
+    const fn = (this.widget as Record<string, unknown>)[this.toggleMethod];
+    if (typeof fn === 'function') {
+      await (fn as () => Promise<void>).call(this.widget);
     } else {
       // Fallback toggle implementation
       if (this.isVisible()) {
@@ -224,17 +227,15 @@ export class WidgetWrapper implements WidgetInstance {
     }
   }
 
-  getInstance(): any {
-    if (this.widget && typeof this.widget[this.getInstanceMethod] === 'function') {
-      return this.widget[this.getInstanceMethod]();
+  getInstance(): T {
+    const fn = (this.widget as Record<string, unknown>)[this.getInstanceMethod];
+    if (typeof fn === 'function') {
+      return (fn as () => T).call(this.widget);
     }
     return this.widget;
   }
 
   isVisible(): boolean {
-    if (this.widget && this.isVisibleProperty in this.widget) {
-      return Boolean(this.widget[this.isVisibleProperty]);
-    }
-    return false;
+    return Boolean((this.widget as Record<string, unknown>)[this.isVisibleProperty]);
   }
 }

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -7,6 +7,15 @@
 /// <reference path="test-types.d.ts" />
 
 import { vi, beforeEach } from 'vitest';
+// Preserve the original console for restoration between tests
+const originalConsole = globalThis.console;
+
+// Silence console warnings and errors during tests to keep output clean
+beforeEach(() => {
+  globalThis.console = originalConsole;
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
 import { DateFormatter } from '../src/core/date-formatter';
 
 // Mock Foundry globals


### PR DESCRIPTION
## Summary
- map window and game references to concrete calendar manager and notes types
- add generic helpers to widget manager and remove cast-heavy sidebar button logic
- expose typed calendar widget macros without casting

## Testing
- `npx eslint packages/core/src/ui/scene-controls.ts packages/core/src/types/foundry-extensions.d.ts packages/core/src/ui/widget-manager.ts packages/core/src/ui/base-widget-manager.ts packages/core/src/types/widget-types.d.ts`
- `npm run test:run` *(incomplete: aborted after 63/101 files due to time)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa4d756d08327bfb6b5e98a291784