### PR TITLE
docs: add AGENTS guidelines for contributors and packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,16 +4,18 @@ This repository provides calendar tools for games in Foundry Virtual Tabletop (V
 
 ## Development Guidelines
 
-- Follow the existing coding standards enforced by ESLint and Prettier.
+- Source code is written in TypeScript and bundled with Rollup; do not commit generated `dist` output.
 - Before committing, run:
   - `npm run lint` to check for linting issues
-  - `npm test` to execute the unit tests
+  - `npm run typecheck` to validate TypeScript types
+  - `npm run test:run` to execute the Vitest unit tests once
+  - `npm run build` to ensure packages compile
 - Use `npm run format` or `npm run lint:fix` to automatically fix formatting problems.
 - Prefer descriptive commit messages and keep pull requests focused.
 
 ## GitHub Workflows & Tooling
 
-- Continuous integration and security checks run via GitHub Actions.
+- Continuous integration runs on Node 18 and 20 via GitHub Actions (`rayners/foundry-module-actions/ci`), performing lint, typecheck, build, tests with coverage, and calendar validation.
 - PR titles should follow the Conventional Commits style to satisfy the Semantic Pull Request workflow.
 - Releases are automated with [release-please](https://github.com/googleapis/release-please); do not manually edit version numbers or `CHANGELOG.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS Instructions
+
+This repository provides calendar tools for games in Foundry Virtual Tabletop (VTT), including modules and compendium packs.
+
+## Development Guidelines
+
+- Follow the existing coding standards enforced by ESLint and Prettier.
+- Before committing, run:
+  - `npm run lint` to check for linting issues
+  - `npm test` to execute the unit tests
+- Use `npm run format` or `npm run lint:fix` to automatically fix formatting problems.
+- Prefer descriptive commit messages and keep pull requests focused.
+
+## GitHub Workflows & Tooling
+
+- Continuous integration and security checks run via GitHub Actions.
+- PR titles should follow the Conventional Commits style to satisfy the Semantic Pull Request workflow.
+- Releases are automated with [release-please](https://github.com/googleapis/release-please); do not manually edit version numbers or `CHANGELOG.md`.
+
+## Foundry Resources
+
+For API and general development information about Foundry VTT consult:
+
+- [Foundry VTT API Reference](https://foundryvtt.com/api/)
+- [Foundry VTT Community Wiki](https://foundryvtt.wiki)
+
+Additional AGENTS.md files in subdirectories may provide more specific instructions.

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS Instructions
+
+This package is part of the Seasons and Stars suite, providing calendar tools for games in Foundry Virtual Tabletop (VTT).
+
+Follow the repository guidelines in the [root AGENTS.md](../../AGENTS.md):
+
+- Run `npm run lint` and `npm test` before committing.
+- Version numbers and changelogs are managed by release-please; avoid editing them manually.
+
+Additional AGENTS.md files in subdirectories may offer more specific instructions.

--- a/packages/core/AGENTS.md
+++ b/packages/core/AGENTS.md
@@ -4,7 +4,7 @@ This package is part of the Seasons and Stars suite, providing calendar tools fo
 
 Follow the repository guidelines in the [root AGENTS.md](../../AGENTS.md):
 
-- Run `npm run lint` and `npm test` before committing.
+- From the repository root, run `npm run lint`, `npm run typecheck`, `npm run test:run`, and `npm run build` before committing.
 - Version numbers and changelogs are managed by release-please; avoid editing them manually.
 
 Additional AGENTS.md files in subdirectories may offer more specific instructions.

--- a/packages/fantasy-pack/AGENTS.md
+++ b/packages/fantasy-pack/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS Instructions
+
+This package is part of the Seasons and Stars suite, providing calendar tools for games in Foundry Virtual Tabletop (VTT).
+
+Follow the repository guidelines in the [root AGENTS.md](../../AGENTS.md):
+
+- Run `npm run lint` and `npm test` before committing.
+- Version numbers and changelogs are managed by release-please; avoid editing them manually.
+
+Additional AGENTS.md files in subdirectories may offer more specific instructions.

--- a/packages/fantasy-pack/AGENTS.md
+++ b/packages/fantasy-pack/AGENTS.md
@@ -4,7 +4,7 @@ This package is part of the Seasons and Stars suite, providing calendar tools fo
 
 Follow the repository guidelines in the [root AGENTS.md](../../AGENTS.md):
 
-- Run `npm run lint` and `npm test` before committing.
+- From the repository root, run `npm run lint`, `npm run typecheck`, `npm run test:run`, and `npm run build` before committing.
 - Version numbers and changelogs are managed by release-please; avoid editing them manually.
 
 Additional AGENTS.md files in subdirectories may offer more specific instructions.

--- a/packages/pf2e-pack/AGENTS.md
+++ b/packages/pf2e-pack/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS Instructions
+
+This package is part of the Seasons and Stars suite, providing calendar tools for games in Foundry Virtual Tabletop (VTT).
+
+Follow the repository guidelines in the [root AGENTS.md](../../AGENTS.md):
+
+- Run `npm run lint` and `npm test` before committing.
+- Version numbers and changelogs are managed by release-please; avoid editing them manually.
+
+Additional AGENTS.md files in subdirectories may offer more specific instructions.

--- a/packages/pf2e-pack/AGENTS.md
+++ b/packages/pf2e-pack/AGENTS.md
@@ -4,7 +4,7 @@ This package is part of the Seasons and Stars suite, providing calendar tools fo
 
 Follow the repository guidelines in the [root AGENTS.md](../../AGENTS.md):
 
-- Run `npm run lint` and `npm test` before committing.
+- From the repository root, run `npm run lint`, `npm run typecheck`, `npm run test:run`, and `npm run build` before committing.
 - Version numbers and changelogs are managed by release-please; avoid editing them manually.
 
 Additional AGENTS.md files in subdirectories may offer more specific instructions.

--- a/packages/scifi-pack/AGENTS.md
+++ b/packages/scifi-pack/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS Instructions
+
+This package is part of the Seasons and Stars suite, providing calendar tools for games in Foundry Virtual Tabletop (VTT).
+
+Follow the repository guidelines in the [root AGENTS.md](../../AGENTS.md):
+
+- Run `npm run lint` and `npm test` before committing.
+- Version numbers and changelogs are managed by release-please; avoid editing them manually.
+
+Additional AGENTS.md files in subdirectories may offer more specific instructions.

--- a/packages/scifi-pack/AGENTS.md
+++ b/packages/scifi-pack/AGENTS.md
@@ -4,7 +4,7 @@ This package is part of the Seasons and Stars suite, providing calendar tools fo
 
 Follow the repository guidelines in the [root AGENTS.md](../../AGENTS.md):
 
-- Run `npm run lint` and `npm test` before committing.
+- From the repository root, run `npm run lint`, `npm run typecheck`, `npm run test:run`, and `npm run build` before committing.
 - Version numbers and changelogs are managed by release-please; avoid editing them manually.
 
 Additional AGENTS.md files in subdirectories may offer more specific instructions.


### PR DESCRIPTION
## Summary
- clarify module goal in AGENTS instructions
- add package-specific AGENTS files for published packs
- document CI workflow and release automation via release-please

## Testing
- `npm run lint`
- `npm test` *(terminated after verifying execution due to verbose output)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa80e9f448327830c7c42d100e8b2