### PR TITLE
feat(fantasy-pack): add Gloranthan calendars

### DIFF
--- a/packages/fantasy-pack/README.md
+++ b/packages/fantasy-pack/README.md
@@ -4,7 +4,7 @@ Calendar pack providing fantasy RPG calendars for the Seasons & Stars module.
 
 ## What This Is
 
-A data module containing 11 fantasy calendar systems for use with Seasons & Stars. Includes calendars from D&D settings, popular RPGs, and generic fantasy systems.
+A data module containing 16 fantasy calendar systems for use with Seasons & Stars. Includes calendars from D&D settings, popular RPGs, Glorantha, and generic fantasy systems.
 
 ## Requirements
 
@@ -24,6 +24,14 @@ Install from Foundry's package manager when available.
 - **Greyhawk Calendar**
 - **Eberron Calendar** (Galifar Calendar)
 - **Athasian Calendar** (Dark Sun)
+
+### Glorantha
+
+- **Orlanthi Calendar**
+- **Brithini Calendar**
+- **Dara Happan Calendar**
+- **Lunar Calendar**
+- **Pamaltelan Calendar**
 
 ### Other RPGs
 

--- a/packages/fantasy-pack/README_FOUNDRY.md
+++ b/packages/fantasy-pack/README_FOUNDRY.md
@@ -4,7 +4,7 @@ Fantasy RPG calendar collection for Seasons & Stars - includes calendars for D&D
 
 ## Calendar Management for Fantasy Campaigns
 
-This calendar pack provides 11 fantasy calendar systems designed for popular RPG settings. Works with the Seasons & Stars calendar module to bring authentic timekeeping to your fantasy campaigns.
+This calendar pack provides 16 fantasy calendar systems designed for popular RPG settings. Works with the Seasons & Stars calendar module to bring authentic timekeeping to your fantasy campaigns.
 
 ## Included Fantasy Calendars
 
@@ -15,6 +15,14 @@ This calendar pack provides 11 fantasy calendar systems designed for popular RPG
 - **Greyhawk Calendar** - Classic D&D setting with festival weeks
 - **Eberron Calendar** - Galifar Calendar with 12 regular 28-day months
 - **Athasian Calendar** - Complex Dark Sun calendar with named year cycles
+
+### Glorantha
+
+- **Orlanthi Calendar** - Standard Gloranthan calendar of five seasons and Sacred Time
+- **Brithini Calendar** - Ten 28-day months used by the Malkioni Brithini
+- **Dara Happan Calendar** - Four 70-day seasons with ten-day weeks
+- **Lunar Calendar** - Imperial calendar of the Lunar Empire
+- **Pamaltelan Calendar** - Southern calendar of four 72-day seasons and Holy Week
 
 ### Popular RPGs
 

--- a/packages/fantasy-pack/calendars/brithini.json
+++ b/packages/fantasy-pack/calendars/brithini.json
@@ -1,0 +1,56 @@
+{
+  "id": "brithini",
+  "translations": {
+    "en": {
+      "label": "Brithini Calendar (Glorantha)",
+      "description": "Malkioni Brithini calendar dividing the 294-day year into ten 28-day months followed by a two-week Sacred Time.",
+      "setting": "Glorantha"
+    }
+  },
+  "year": {
+    "epoch": 0,
+    "currentYear": 1625,
+    "prefix": "",
+    "suffix": " ST",
+    "startDay": 0
+  },
+  "leapYear": { "rule": "none" },
+  "months": [
+    {
+      "name": "Malkinel",
+      "abbreviation": "Mal",
+      "days": 28,
+      "description": "First month of the Brithini year."
+    },
+    { "name": "Demas", "abbreviation": "Dem", "days": 28, "description": "Second month." },
+    { "name": "Kaldine", "abbreviation": "Kal", "days": 28, "description": "Third month." },
+    { "name": "Wemago", "abbreviation": "Wem", "days": 28, "description": "Fourth month." },
+    { "name": "Untha", "abbreviation": "Unt", "days": 28, "description": "Fifth month." },
+    { "name": "Intha", "abbreviation": "Int", "days": 28, "description": "Sixth month." },
+    { "name": "Brithe", "abbreviation": "Bri", "days": 28, "description": "Seventh month." },
+    { "name": "Sona", "abbreviation": "Son", "days": 28, "description": "Eighth month." },
+    { "name": "Odemak", "abbreviation": "Ode", "days": 28, "description": "Ninth month." },
+    { "name": "Tilntel", "abbreviation": "Til", "days": 28, "description": "Tenth month." },
+    {
+      "name": "Sacred Time",
+      "abbreviation": "Sac",
+      "days": 14,
+      "description": "Two weeks of holy observances."
+    }
+  ],
+  "weekdays": [
+    { "name": "Freezeday", "abbreviation": "Frz" },
+    { "name": "Waterday", "abbreviation": "Wat" },
+    { "name": "Clayday", "abbreviation": "Cla" },
+    { "name": "Windsday", "abbreviation": "Win" },
+    { "name": "Fireday", "abbreviation": "Fir" },
+    { "name": "Wildday", "abbreviation": "Wld" },
+    { "name": "Godsday", "abbreviation": "Gds" }
+  ],
+  "intercalary": [],
+  "time": {
+    "hoursInDay": 24,
+    "minutesInHour": 60,
+    "secondsInMinute": 60
+  }
+}

--- a/packages/fantasy-pack/calendars/dara-happan.json
+++ b/packages/fantasy-pack/calendars/dara-happan.json
@@ -1,0 +1,68 @@
+{
+  "id": "dara-happan",
+  "translations": {
+    "en": {
+      "label": "Dara Happan Calendar (Glorantha)",
+      "description": "Calendar of the Dara Happan people, dividing the year into four 70-day seasons of ten-day weeks followed by a 14-day Sacred Time.",
+      "setting": "Glorantha"
+    }
+  },
+  "year": {
+    "epoch": 0,
+    "currentYear": 1625,
+    "prefix": "",
+    "suffix": " ST",
+    "startDay": 0
+  },
+  "leapYear": { "rule": "none" },
+  "months": [
+    {
+      "name": "Youth Season",
+      "abbreviation": "You",
+      "days": 70,
+      "description": "The year's beginning and season of renewal."
+    },
+    {
+      "name": "Sky Season",
+      "abbreviation": "Sky",
+      "days": 70,
+      "description": "Clear skies and high worship."
+    },
+    {
+      "name": "Harvest Season",
+      "abbreviation": "Har",
+      "days": 70,
+      "description": "Time of gathering and plenty."
+    },
+    {
+      "name": "Dying Season",
+      "abbreviation": "Dye",
+      "days": 70,
+      "description": "The waning year and approach of darkness."
+    },
+    {
+      "name": "Sacred Time",
+      "abbreviation": "Sac",
+      "days": 14,
+      "description": "Fourteen days of holy rites closing the year."
+    }
+  ],
+  "weekdays": [
+    { "name": "First Day", "abbreviation": "D1" },
+    { "name": "Second Day", "abbreviation": "D2" },
+    { "name": "Third Day", "abbreviation": "D3" },
+    { "name": "Fourth Day", "abbreviation": "D4" },
+    { "name": "Fifth Day", "abbreviation": "D5" },
+    { "name": "Sixth Day", "abbreviation": "D6" },
+    { "name": "Seventh Day", "abbreviation": "D7" },
+    { "name": "Eighth Day", "abbreviation": "D8" },
+    { "name": "Ninth Day", "abbreviation": "D9" },
+    { "name": "Tenth Day", "abbreviation": "D10" }
+  ],
+  "intercalary": [],
+  "time": {
+    "hoursInDay": 24,
+    "minutesInHour": 60,
+    "secondsInMinute": 60
+  }
+}

--- a/packages/fantasy-pack/calendars/lunar.json
+++ b/packages/fantasy-pack/calendars/lunar.json
@@ -1,0 +1,46 @@
+{
+  "id": "lunar",
+  "translations": {
+    "en": {
+      "label": "Lunar Calendar (Glorantha)",
+      "description": "Imperial Lunar calendar invented by Irrippi Ontor. Features ten 28-day months and a Sacred Time of 14 days.",
+      "setting": "Glorantha"
+    }
+  },
+  "year": {
+    "epoch": 0,
+    "currentYear": 1625,
+    "prefix": "",
+    "suffix": " ST",
+    "startDay": 0
+  },
+  "leapYear": { "rule": "none" },
+  "months": [
+    { "name": "Month of Innocence", "abbreviation": "Inn", "days": 28 },
+    { "name": "Month of Glamour", "abbreviation": "Gla", "days": 28 },
+    { "name": "Month of Anticipation", "abbreviation": "Ant", "days": 28 },
+    { "name": "Month of Ascension", "abbreviation": "Asc", "days": 28 },
+    { "name": "Month of Zenith", "abbreviation": "Zen", "days": 28 },
+    { "name": "Month of Change", "abbreviation": "Cha", "days": 28 },
+    { "name": "Month of Descent", "abbreviation": "Des", "days": 28 },
+    { "name": "Month of Moonset", "abbreviation": "Moo", "days": 28 },
+    { "name": "Month of Suffering", "abbreviation": "Suf", "days": 28 },
+    { "name": "Month of Balance", "abbreviation": "Bal", "days": 28 },
+    { "name": "Sacred Time", "abbreviation": "Sac", "days": 14 }
+  ],
+  "weekdays": [
+    { "name": "Veriday", "abbreviation": "Ver" },
+    { "name": "Lesilday", "abbreviation": "Les" },
+    { "name": "Gerraday", "abbreviation": "Ger" },
+    { "name": "Rashoday", "abbreviation": "Ras" },
+    { "name": "Ulurday", "abbreviation": "Ulu" },
+    { "name": "Nathaday", "abbreviation": "Nat" },
+    { "name": "Zayday", "abbreviation": "Zay" }
+  ],
+  "intercalary": [],
+  "time": {
+    "hoursInDay": 24,
+    "minutesInHour": 60,
+    "secondsInMinute": 60
+  }
+}

--- a/packages/fantasy-pack/calendars/orlanthi.json
+++ b/packages/fantasy-pack/calendars/orlanthi.json
@@ -1,0 +1,93 @@
+{
+  "id": "orlanthi",
+  "translations": {
+    "en": {
+      "label": "Orlanthi Calendar (Glorantha)",
+      "description": "Standard Gloranthan calendar used by the Orlanthi and many other cultures. Divides the 294-day year into five 8-week seasons followed by a two-week Sacred Time.",
+      "setting": "Glorantha"
+    }
+  },
+  "year": {
+    "epoch": 0,
+    "currentYear": 1625,
+    "prefix": "",
+    "suffix": " ST",
+    "startDay": 0
+  },
+  "leapYear": {
+    "rule": "none"
+  },
+  "months": [
+    {
+      "name": "Sea Season",
+      "abbreviation": "Sea",
+      "days": 56,
+      "description": "The season of growth and trade."
+    },
+    {
+      "name": "Fire Season",
+      "abbreviation": "Fir",
+      "days": 56,
+      "description": "The warm season of conflict and campaigning."
+    },
+    {
+      "name": "Earth Season",
+      "abbreviation": "Ear",
+      "days": 56,
+      "description": "The harvest season of plenty."
+    },
+    {
+      "name": "Dark Season",
+      "abbreviation": "Drk",
+      "days": 56,
+      "description": "The cold, dangerous season when spirits walk."
+    },
+    {
+      "name": "Storm Season",
+      "abbreviation": "Sto",
+      "days": 56,
+      "description": "The tempestuous season of winter gales."
+    },
+    {
+      "name": "Sacred Time",
+      "abbreviation": "Sac",
+      "days": 14,
+      "description": "Two weeks of rituals marking year's end and renewal."
+    }
+  ],
+  "weekdays": [
+    {
+      "name": "Freezeday",
+      "abbreviation": "Frz",
+      "description": "First day dedicated to air and cold."
+    },
+    {
+      "name": "Waterday",
+      "abbreviation": "Wat",
+      "description": "Second day honoring water and rivers."
+    },
+    { "name": "Clayday", "abbreviation": "Cla", "description": "Third day of earth and craft." },
+    {
+      "name": "Windsday",
+      "abbreviation": "Win",
+      "description": "Fourth day for storms and change."
+    },
+    {
+      "name": "Fireday",
+      "abbreviation": "Fir",
+      "description": "Fifth day celebrating flame and light."
+    },
+    {
+      "name": "Wildday",
+      "abbreviation": "Wld",
+      "description": "Sixth day tied to beasts and the untamed."
+    },
+    { "name": "Godsday", "abbreviation": "Gds", "description": "Seventh day reserved for worship." }
+  ],
+  "intercalary": [],
+  "time": {
+    "hoursInDay": 24,
+    "minutesInHour": 60,
+    "secondsInMinute": 60
+  }
+}

--- a/packages/fantasy-pack/calendars/pamaltelan.json
+++ b/packages/fantasy-pack/calendars/pamaltelan.json
@@ -1,0 +1,49 @@
+{
+  "id": "pamaltelan",
+  "translations": {
+    "en": {
+      "label": "Pamaltelan Calendar (Glorantha)",
+      "description": "Calendar of the Doraddi and southern peoples with four 72-day seasons of six-day weeks and a final Holy Week of six days.",
+      "setting": "Glorantha"
+    }
+  },
+  "year": {
+    "epoch": 0,
+    "currentYear": 1625,
+    "prefix": "",
+    "suffix": " ST",
+    "startDay": 0
+  },
+  "leapYear": { "rule": "none" },
+  "months": [
+    {
+      "name": "Season One",
+      "abbreviation": "S1",
+      "days": 72,
+      "description": "First season of the Pamaltelan year."
+    },
+    { "name": "Season Two", "abbreviation": "S2", "days": 72, "description": "Second season." },
+    { "name": "Season Three", "abbreviation": "S3", "days": 72, "description": "Third season." },
+    { "name": "Season Four", "abbreviation": "S4", "days": 72, "description": "Fourth season." },
+    {
+      "name": "Holy Week",
+      "abbreviation": "Hol",
+      "days": 6,
+      "description": "Sacred week marking the end of the year."
+    }
+  ],
+  "weekdays": [
+    { "name": "First Day", "abbreviation": "D1" },
+    { "name": "Second Day", "abbreviation": "D2" },
+    { "name": "Third Day", "abbreviation": "D3" },
+    { "name": "Fourth Day", "abbreviation": "D4" },
+    { "name": "Fifth Day", "abbreviation": "D5" },
+    { "name": "Sixth Day", "abbreviation": "D6" }
+  ],
+  "intercalary": [],
+  "time": {
+    "hoursInDay": 24,
+    "minutesInHour": 60,
+    "secondsInMinute": 60
+  }
+}


### PR DESCRIPTION
## Summary
- add Orlanthi, Brithini, Dara Happan, Lunar, and Pamaltelan calendars to fantasy pack
- document new Glorantha calendar options

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6463a0ec48327b53ac4cd10bcaf62