### PR TITLE
feat(ui): add filterable calendar selection dialog

### DIFF
--- a/packages/core/templates/calendar-selection-dialog.hbs
+++ b/packages/core/templates/calendar-selection-dialog.hbs
@@ -1,164 +1,48 @@
 <div class="dialog-content">
   <form class="standard-form">
-    <div class="form-group">
-      <label>{{localize "SEASONS_STARS.dialog.calendar_selection.choose_calendar"}}</label>
-      <p class="hint">{{localize "SEASONS_STARS.dialog.calendar_selection.choose_hint"}}</p>
-      
-      <div class="form-fields">
-        <div class="calendar-selection-grid">
-          {{#each calendars}}
-          <div class="calendar-card ui-control {{#if isCurrent}}active{{/if}} {{#if isSelected}}picked{{/if}} {{#if isVariant}}variant{{/if}} {{#if hierarchyLevel}}hierarchy-level-{{hierarchyLevel}}{{/if}} source-{{sourceType}}" 
-               data-action="selectCalendar"
-               data-calendar-id="{{id}}" 
-               title="{{description}}">
-            
-            <div class="card-header flexcol">
-              <div class="calendar-title-row flexrow">
-                <div class="calendar-title-info flexcol">
-                  <h4 class="calendar-name">
-                    {{#if isVariant}}
-                    <span class="variant-indicator">
-                      <i class="fas fa-code-branch"></i>
-                    </span>
-                    {{/if}}
-                    {{label}}
-                  </h4>
-                  {{#if setting}}
-                  <span class="calendar-setting">{{setting}}</span>
-                  {{/if}}
-                  {{#if variantInfo}}
-                  <span class="variant-info">{{variantInfo}}</span>
-                  {{/if}}
-                </div>
-                <div class="calendar-badges flexrow">
-                  {{#if isCurrent}}
-                  <div class="current-badge" data-tooltip="Current active calendar">
-                    <i class="fas fa-star"></i>
-                  </div>
-                  {{/if}}
-                  {{#if isModuleSource}}
-                  <div class="module-badge" data-tooltip="{{sourceDescription}}">
-                    <i class="fas fa-puzzle-piece"></i>
-                  </div>
-                  {{else if isExternalSource}}
-                  <div class="external-badge" data-tooltip="{{sourceDescription}}">
-                    <i class="fas fa-cloud"></i>
-                  </div>
-                  {{/if}}
-                </div>
-              </div>
-              <div class="source-info flexrow">
-                <i class="{{sourceIcon}} source-icon"></i>
-                <span class="source-label">{{sourceLabel}}</span>
-              </div>
-            </div>
+    <div class="search-filters flexrow">
+      <input type="text" class="search-input" placeholder="{{localize 'SEASONS_STARS.dialog.calendar_selection.search'}}" value="{{searchQuery}}" data-action="search" />
+      <select data-action="setFilter" data-filter-type="tag">
+        <option value="">{{localize 'SEASONS_STARS.dialog.calendar_selection.filter_tag'}}</option>
+        {{#each filterOptions.tags}}
+        <option value="{{this}}" {{#if (eq ../selectedFilters.tag this)}}selected{{/if}}>{{this}}</option>
+        {{/each}}
+      </select>
+      <select data-action="setFilter" data-filter-type="author">
+        <option value="">{{localize 'SEASONS_STARS.dialog.calendar_selection.filter_author'}}</option>
+        {{#each filterOptions.authors}}
+        <option value="{{this}}" {{#if (eq ../selectedFilters.author this)}}selected{{/if}}>{{this}}</option>
+        {{/each}}
+      </select>
+      <select data-action="setFilter" data-filter-type="source">
+        <option value="">{{localize 'SEASONS_STARS.dialog.calendar_selection.filter_source'}}</option>
+        {{#each filterOptions.sources}}
+        <option value="{{id}}" {{#if (eq ../selectedFilters.source id)}}selected{{/if}}>{{label}}</option>
+        {{/each}}
+      </select>
+    </div>
 
-            <div class="card-content flexcol">
-              <p class="calendar-description">{{description}}</p>
-              
-              <div class="preview-section">
-                <div class="sample-preview">
-                  <label>{{localize "SEASONS_STARS.dialog.calendar_selection.sample"}}:</label>
-                  <span class="sample-date">{{sampleDate}}</span>
-                </div>
-                
-                <div class="mini-preview">
-                  <label>Mini Widget:</label>
-                  <span class="mini-format">{{miniPreview}}</span>
-                </div>
-              </div>
-            </div>
-
-            <div class="card-actions flexrow">
-              <button type="button" data-action="previewCalendar" class="button" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.preview_tooltip'}}">
-                <i class="fas fa-eye"></i>
-                {{localize "SEASONS_STARS.dialog.calendar_selection.preview"}}
-              </button>
-              {{#if isSelected}}
-              <i class="fas fa-check-circle selected-indicator"></i>
-              {{/if}}
-            </div>
-          </div>
-          {{/each}}
-          
-          <!-- File Picker Card -->
-          <div class="calendar-card ui-control file-picker-card {{#if filePickerActive}}active{{/if}} {{#if filePickerSelected}}picked{{/if}}" 
-               {{#if selectedFilePath}}data-action="selectCalendar" data-calendar-id="__FILE_PICKER__"{{else}}data-action="openFilePicker"{{/if}}
-               title="{{localize 'SEASONS_STARS.dialog.calendar_selection.custom_file_hint'}}">
-            
-            <div class="card-header flexcol">
-              <div class="calendar-title-row flexrow">
-                <div class="calendar-title-info flexcol">
-                  <h4 class="calendar-name">
-                    <span class="file-picker-indicator">
-                      <i class="fas fa-folder-open"></i>
-                    </span>
-                    {{localize "SEASONS_STARS.dialog.calendar_selection.custom_file"}}
-                  </h4>
-                  {{#if selectedFilePath}}
-                  <span class="calendar-setting">{{selectedFilePath}}</span>
-                  {{/if}}
-                </div>
-                <div class="calendar-badges flexrow">
-                  {{#if filePickerActive}}
-                  <div class="current-badge" data-tooltip="Current active calendar">
-                    <i class="fas fa-star"></i>
-                  </div>
-                  {{/if}}
-                  <div class="file-badge" data-tooltip="Custom calendar file">
-                    <i class="fas fa-file-alt"></i>
-                  </div>
-                </div>
-              </div>
-              <div class="source-info flexrow">
-                <i class="fas fa-folder-open source-icon"></i>
-                <span class="source-label">Custom File</span>
-              </div>
-            </div>
-
-            <div class="card-content flexcol">
-              <p class="calendar-description">
-                {{#if selectedFilePath}}
-                  {{localize "SEASONS_STARS.dialog.calendar_selection.file_loaded"}}
-                {{else}}
-                  {{localize "SEASONS_STARS.dialog.calendar_selection.custom_file_hint"}}
-                {{/if}}
-              </p>
-              
-              <div class="preview-section">
-                {{#if selectedFilePath}}
-                <div class="sample-preview">
-                  <label>{{localize "SEASONS_STARS.dialog.calendar_selection.file_path"}}:</label>
-                  <span class="sample-date file-path">{{selectedFilePath}}</span>
-                </div>
-                {{else}}
-                <div class="sample-preview">
-                  <label>{{localize "SEASONS_STARS.dialog.calendar_selection.status"}}:</label>
-                  <span class="sample-date">{{localize "SEASONS_STARS.dialog.calendar_selection.click_to_select"}}</span>
-                </div>
-                {{/if}}
-              </div>
-            </div>
-
-            <div class="card-actions flexrow">
-              {{#if selectedFilePath}}
-              <button type="button" data-action="clearFilePicker" class="button" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.clear_file'}}">
-                <i class="fas fa-times"></i>
-                {{localize "SEASONS_STARS.dialog.calendar_selection.clear"}}
-              </button>
-              {{else}}
-              <button type="button" data-action="openFilePicker" class="button" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.browse_tooltip'}}">
-                <i class="fas fa-folder-open"></i>
-                {{localize "SEASONS_STARS.dialog.calendar_selection.browse"}}
-              </button>
-              {{/if}}
-              {{#if filePickerActive}}
-              <i class="fas fa-check-circle selected-indicator"></i>
-              {{/if}}
-            </div>
-          </div>
-        </div>
+    <div class="calendar-list">
+      {{#each calendars}}
+      <div class="calendar-row ui-control {{#if isCurrent}}active{{/if}} {{#if isSelected}}picked{{/if}}" data-action="selectCalendar" data-calendar-id="{{id}}">
+        <span class="calendar-name">{{label}}</span>
+        <span class="calendar-tags">{{#each tags}}<span class="tag">{{this}}</span>{{/each}}</span>
+        <span class="calendar-author">{{author}}</span>
+        <span class="calendar-source">{{sourceLabel}}</span>
       </div>
+      {{/each}}
+    </div>
+
+    <div class="calendar-details">
+      {{#if selected}}
+      <h3>{{selected.label}}</h3>
+      {{#if selected.description}}<p class="description">{{selected.description}}</p>{{/if}}
+      {{#if selected.sampleDate}}<div class="sample">{{selected.sampleDate}}</div>{{/if}}
+      {{#if selected.miniPreview}}<div class="mini">{{selected.miniPreview}}</div>{{/if}}
+      {{/if}}
+      {{#if selectedFilePath}}
+      <div class="file-info">{{localize 'SEASONS_STARS.dialog.calendar_selection.file_path'}}: {{selectedFilePath}}</div>
+      {{/if}}
     </div>
   </form>
 
@@ -166,9 +50,10 @@
   <div class="no-calendars flexcol">
     <i class="fas fa-calendar-times no-calendars-icon"></i>
     <div class="no-calendars-message">
-      <h4>{{localize "SEASONS_STARS.dialog.calendar_selection.no_calendars"}}</h4>
-      <p>{{localize "SEASONS_STARS.dialog.calendar_selection.no_calendars_hint"}}</p>
+      <h4>{{localize 'SEASONS_STARS.dialog.calendar_selection.no_calendars'}}</h4>
+      <p>{{localize 'SEASONS_STARS.dialog.calendar_selection.no_calendars_hint'}}</p>
     </div>
   </div>
   {{/unless}}
 </div>
+

--- a/packages/core/test/mini-widget-settings-integration.test.ts
+++ b/packages/core/test/mini-widget-settings-integration.test.ts
@@ -29,6 +29,7 @@ globalThis.game = {
     register: vi.fn((module: string, key: string, data: any) => {
       mockRegisteredSettings.set(`${module}.${key}`, data);
     }),
+    registerMenu: vi.fn(),
   },
   seasonsStars: {
     manager: {

--- a/packages/core/test/setup.ts
+++ b/packages/core/test/setup.ts
@@ -105,6 +105,7 @@ export function setupFoundryEnvironment(): void {
     get: vi.fn(),
     set: vi.fn(),
     register: vi.fn(),
+    registerMenu: vi.fn(),
   };
 
   (globalThis as any).game.time = (globalThis as any).game.time || {


### PR DESCRIPTION
## Summary
- redesign calendar selection with compact list built on ApplicationV2
- enable tag/author/source filtering and text search
- replace settings dropdown with menu button opening new dialog

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`

## Mockups
```
[Search ][tag v]
[author v][source v]
---------------------------------------
| Calendar Name | tags | author | src|
---------------------------------------
| ...                               |

[Browse File] [Clear]       [Cancel][Select]
```


------
https://chatgpt.com/codex/tasks/task_e_68c657e071a883279db2856aaa002b5a