### PR TITLE
test: enforce deterministic tests

### DIFF
--- a/packages/core/src/core/settings-preview.ts
+++ b/packages/core/src/core/settings-preview.ts
@@ -459,7 +459,7 @@ function updateTimeAdvancementExplanation(ratio: number): void {
 /**
  * Generate human-readable ratio explanation
  */
-function generateRatioExplanation(ratio: number): string {
+export function generateRatioExplanation(ratio: number): string {
   if (ratio === 1.0) {
     return `<strong>Real Time:</strong> 1 second of real time = 1 second of game time`;
   } else if (ratio > 1.0) {
@@ -482,7 +482,7 @@ function generateRatioExplanation(ratio: number): string {
 /**
  * Generate technical interval explanation
  */
-function generateIntervalExplanation(ratio: number, interval: number): string {
+export function generateIntervalExplanation(ratio: number, interval: number): string {
   const intervalSeconds = interval / 1000;
   const gameSecondsAdvanced = ratio * intervalSeconds;
 

--- a/packages/core/test/AGENTS.md
+++ b/packages/core/test/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/core/test/CLAUDE.md
+++ b/packages/core/test/CLAUDE.md
@@ -1,0 +1,10 @@
+# Test Suite Guidelines
+
+- Each test file targets a single source module or workflow.
+- No conditional logic (`if`, `switch`, ternary operations, or optional chaining for control flow`).
+- Use deterministic data; avoid random values or relative dates.
+- Assertions must be explicit and exact (`expect(x).toBe(2)`).
+- Prefer exercising real functionality and data over mocks whenever feasible.
+- Unit tests isolate one source file; integration and regression tests cover complete workflows with separate scenarios per test.
+- Keep tests self-contained with no external state.
+- Before committing, run `npm run lint`, `npm run typecheck`, `npm run test:run`, and `npm run build`.

--- a/packages/core/test/date-formatter-integration.test.ts
+++ b/packages/core/test/date-formatter-integration.test.ts
@@ -160,34 +160,33 @@ describe('DateFormatter Integration Tests', () => {
           readFileSync(eberronPath, 'utf8')
         ) as SeasonsStarsCalendar;
 
-        if (eberronCalendar.dateFormats) {
-          const formatter = new DateFormatter(eberronCalendar);
+        expect(eberronCalendar.dateFormats).toBeDefined();
+        const formatter = new DateFormatter(eberronCalendar);
 
-          // Test a few key formats to ensure they compile and execute
-          const testDate = {
-            year: 998,
-            month: 1,
-            day: 15,
-            weekday: 1,
-            time: { hour: 12, minute: 30, second: 0 },
-          } as CalendarDate;
+        // Test a few key formats to ensure they compile and execute
+        const testDate = {
+          year: 998,
+          month: 1,
+          day: 15,
+          weekday: 1,
+          time: { hour: 12, minute: 30, second: 0 },
+        } as CalendarDate;
 
-          // Test formats that were fixed for syntax
-          expect(() => formatter.formatNamed(testDate, 'week-number')).not.toThrow();
-          expect(() => formatter.formatNamed(testDate, 'historical')).not.toThrow();
-          expect(() => formatter.formatNamed(testDate, 'treaty')).not.toThrow();
+        // Test formats that were fixed for syntax
+        expect(() => formatter.formatNamed(testDate, 'week-number')).not.toThrow();
+        expect(() => formatter.formatNamed(testDate, 'historical')).not.toThrow();
+        expect(() => formatter.formatNamed(testDate, 'treaty')).not.toThrow();
 
-          // Verify the math operations work correctly
-          const weekNumber = formatter.formatNamed(testDate, 'week-number');
-          expect(weekNumber).toContain('Week');
-          expect(weekNumber).toContain('998 YK');
+        // Verify the math operations work correctly
+        const weekNumber = formatter.formatNamed(testDate, 'week-number');
+        expect(weekNumber).toContain('Week');
+        expect(weekNumber).toContain('998 YK');
 
-          const historical = formatter.formatNamed(testDate, 'historical');
-          expect(historical).toContain('104 years'); // 998 - 894
+        const historical = formatter.formatNamed(testDate, 'historical');
+        expect(historical).toContain('104 years'); // 998 - 894
 
-          const treaty = formatter.formatNamed(testDate, 'treaty');
-          expect(treaty).toContain('+2'); // 998 - 996
-        }
+        const treaty = formatter.formatNamed(testDate, 'treaty');
+        expect(treaty).toContain('+2'); // 998 - 996
       } catch (error) {
         throw new Error(`Eberron calendar template validation failed: ${error.message}`);
       }
@@ -207,44 +206,44 @@ describe('DateFormatter Integration Tests', () => {
         );
         const starTrekVariants = JSON.parse(readFileSync(starTrekPath, 'utf8'));
 
-        // Get the Star Trek variant from the variants object
-        const starTrekCalendar = starTrekVariants.variants?.['star-trek-calendar'];
-        if (starTrekCalendar?.overrides?.dateFormats) {
-          // Create a test calendar by merging base Gregorian with Star Trek overrides
-          const gregorianPath = join(__dirname, '..', 'calendars', 'gregorian.json');
-          const baseCalendar = JSON.parse(
-            readFileSync(gregorianPath, 'utf8')
-          ) as SeasonsStarsCalendar;
+        // Get the Federation Standard variant from the variants object
+        const starTrekCalendar = starTrekVariants.variants?.['federation-standard'];
+        expect(starTrekCalendar?.overrides?.dateFormats).toBeDefined();
 
-          // Apply Star Trek overrides
-          const testCalendar = {
-            ...baseCalendar,
-            id: 'star-trek-test',
-            dateFormats: starTrekCalendar.overrides.dateFormats,
-          };
+        // Create a test calendar by merging base Gregorian with Star Trek overrides
+        const gregorianPath = join(__dirname, '..', 'calendars', 'gregorian.json');
+        const baseCalendar = JSON.parse(
+          readFileSync(gregorianPath, 'utf8')
+        ) as SeasonsStarsCalendar;
 
-          const formatter = new DateFormatter(testCalendar);
+        // Apply Star Trek overrides
+        const testCalendar = {
+          ...baseCalendar,
+          id: 'star-trek-test',
+          dateFormats: starTrekCalendar.overrides.dateFormats,
+        };
 
-          const testDate = {
-            year: 2370,
-            month: 1,
-            day: 15,
-            weekday: 1,
-            time: { hour: 12, minute: 30, second: 0 },
-          } as CalendarDate;
+        const formatter = new DateFormatter(testCalendar);
 
-          // Test formats that were fixed for syntax
-          expect(() => formatter.formatNamed(testDate, 'tos-stardate')).not.toThrow();
-          expect(() => formatter.formatNamed(testDate, 'tng-stardate')).not.toThrow();
-          expect(() => formatter.formatNamed(testDate, 'ds9-stardate')).not.toThrow();
+        const testDate = {
+          year: 2370,
+          month: 1,
+          day: 15,
+          weekday: 1,
+          time: { hour: 12, minute: 30, second: 0 },
+        } as CalendarDate;
 
-          // Verify the stardate calculations work
-          const tosStardate = formatter.formatNamed(testDate, 'tos-stardate');
-          expect(tosStardate).toContain('1070.15'); // (2370-1300).15
+        // Test formats that were fixed for syntax
+        expect(() => formatter.formatNamed(testDate, 'tos-stardate')).not.toThrow();
+        expect(() => formatter.formatNamed(testDate, 'tng-stardate')).not.toThrow();
+        expect(() => formatter.formatNamed(testDate, 'ds9-stardate')).not.toThrow();
 
-          const tngStardate = formatter.formatNamed(testDate, 'tng-stardate');
-          expect(tngStardate).toContain('47000.'); // prefix 47 + (2370-2370) + day
-        }
+        // Verify the stardate calculations work
+        const tosStardate = formatter.formatNamed(testDate, 'tos-stardate');
+        expect(tosStardate).toBe('1070.15'); // (2370-1300).15
+
+        const tngStardate = formatter.formatNamed(testDate, 'tng-stardate');
+        expect(tngStardate).toBe('47015.0'); // prefix 47 + dayOfYear 15
       } catch (error) {
         throw new Error(`Star Trek calendar template validation failed: ${error.message}`);
       }
@@ -258,30 +257,32 @@ describe('DateFormatter Integration Tests', () => {
         { filename: 'traveller-imperial.json', pack: 'scifi-pack' },
       ];
 
+      const basePaths: Record<string, string> = {
+        core: join(__dirname, '..', 'calendars'),
+        'fantasy-pack': join(__dirname, '..', '..', '..', 'packages', 'fantasy-pack', 'calendars'),
+        'scifi-pack': join(__dirname, '..', '..', '..', 'packages', 'scifi-pack', 'calendars'),
+      };
+
       calendarFiles.forEach(({ filename, pack }) => {
         try {
-          const calendarPath =
-            pack === 'core'
-              ? join(__dirname, '..', 'calendars', filename)
-              : join(__dirname, '..', '..', '..', 'packages', pack, 'calendars', filename);
+          const calendarPath = join(basePaths[pack], filename);
           const calendar = JSON.parse(readFileSync(calendarPath, 'utf8')) as SeasonsStarsCalendar;
 
-          if (calendar.dateFormats) {
-            Object.entries(calendar.dateFormats).forEach(([formatName, template]) => {
-              if (typeof template === 'string') {
-                try {
-                  // Test that the template can be compiled
-                  Handlebars.compile(template);
-                } catch (compileError) {
-                  throw new Error(
-                    `Template '${formatName}' in ${filename} has syntax error: ${compileError.message}`
-                  );
-                }
+          const dateFormats = calendar.dateFormats ?? {};
+          Object.entries(dateFormats)
+            .filter(([, template]) => typeof template === 'string')
+            .forEach(([formatName, template]) => {
+              try {
+                // Test that the template can be compiled
+                Handlebars.compile(template as string);
+              } catch (compileError) {
+                throw new Error(
+                  `Template '${formatName}' in ${filename} has syntax error: ${(compileError as Error).message}`
+                );
               }
             });
-          }
         } catch (error) {
-          throw new Error(`Calendar ${filename} validation failed: ${error.message}`);
+          throw new Error(`Calendar ${filename} validation failed: ${(error as Error).message}`);
         }
       });
     });

--- a/packages/core/test/external-calendar-registration.test.ts
+++ b/packages/core/test/external-calendar-registration.test.ts
@@ -38,13 +38,10 @@ describe('External Calendar Registration Hook', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     manager = new CalendarManager();
+    hookCallback = undefined;
 
-    // Capture the hook callback when it's called
-    (global.Hooks.callAll as any).mockImplementation((hookName: string, payload: any) => {
-      if (hookName === 'seasons-stars:registerExternalCalendars') {
-        hookCallback = payload;
-      }
-    });
+    // Capture calls to the registration hook without conditional logic
+    (global.Hooks.callAll as any).mockImplementation(() => {});
   });
 
   it('should fire registration hook during initialization', async () => {
@@ -69,6 +66,9 @@ describe('External Calendar Registration Hook', () => {
     vi.spyOn(manager as any, 'completeInitialization').mockResolvedValue(undefined);
 
     await manager.initialize();
+    hookCallback = (global.Hooks.callAll as any).mock.calls.find(
+      ([hookName]: any[]) => hookName === 'seasons-stars:registerExternalCalendars'
+    )[1];
 
     // Ensure we captured the hook callback
     expect(hookCallback).toBeDefined();
@@ -137,6 +137,9 @@ describe('External Calendar Registration Hook', () => {
     vi.spyOn(manager as any, 'completeInitialization').mockResolvedValue(undefined);
 
     await manager.initialize();
+    hookCallback = (global.Hooks.callAll as any).mock.calls.find(
+      ([hookName]: any[]) => hookName === 'seasons-stars:registerExternalCalendars'
+    )[1];
 
     // Test with invalid data (missing id)
     const invalidCalendar = {
@@ -155,6 +158,9 @@ describe('External Calendar Registration Hook', () => {
     vi.spyOn(manager as any, 'completeInitialization').mockResolvedValue(undefined);
 
     await manager.initialize();
+    hookCallback = (global.Hooks.callAll as any).mock.calls.find(
+      ([hookName]: any[]) => hookName === 'seasons-stars:registerExternalCalendars'
+    )[1];
 
     // Mock loadCalendar to return false (validation failure)
     vi.spyOn(manager, 'loadCalendar').mockReturnValue(false);

--- a/packages/core/test/settings-preview.test.ts
+++ b/packages/core/test/settings-preview.test.ts
@@ -1,69 +1,47 @@
 /**
- * Tests for Settings Preview functionality
+ * Tests for Settings Preview explanations
  */
 
 import { describe, it, expect } from 'vitest';
+import * as settingsPreview from '../src/core/settings-preview';
 
-// Since the functions are not exported, we'll test through a simple simulation
-describe('Time Advancement Ratio Explanations', () => {
-  // Replicate the explanation generation functions for testing
-  function generateRatioExplanation(ratio: number): string {
-    if (ratio === 1.0) {
-      return `<strong>Real Time:</strong> 1 second of real time = 1 second of game time`;
-    } else if (ratio > 1.0) {
-      if (ratio === Math.floor(ratio)) {
-        return `<strong>Accelerated Time:</strong> 1 second of real time = ${ratio} seconds of game time (${ratio}x speed)`;
-      } else {
-        return `<strong>Accelerated Time:</strong> 1 second of real time = ${ratio} seconds of game time (${ratio}x speed)`;
-      }
-    } else {
-      const realSecondsPerGameSecond = Math.round(1 / ratio);
-      if (realSecondsPerGameSecond <= 60) {
-        return `<strong>Slow Time:</strong> ${realSecondsPerGameSecond} seconds of real time = 1 second of game time`;
-      } else {
-        const realMinutesPerGameSecond = Math.round(realSecondsPerGameSecond / 60);
-        return `<strong>Very Slow Time:</strong> ${realMinutesPerGameSecond} minutes of real time = 1 second of game time`;
-      }
-    }
-  }
+const { generateRatioExplanation, generateIntervalExplanation } = settingsPreview as any;
 
-  function generateIntervalExplanation(ratio: number, interval: number): string {
-    const intervalSeconds = interval / 1000;
-    const gameSecondsAdvanced = ratio * intervalSeconds;
+function calculateOptimalInterval(ratio: number): number {
+  return Math.max(10000, Math.ceil(1000 / ratio));
+}
 
-    return `Technical: Every ${intervalSeconds} seconds, game time advances by ${gameSecondsAdvanced} seconds`;
-  }
-
-  describe('Ratio Explanations', () => {
-    it('should explain 1:1 ratio correctly', () => {
+describe('Settings Preview', () => {
+  describe('Ratio explanations', () => {
+    it('explains 1:1 ratio', () => {
       const explanation = generateRatioExplanation(1.0);
       expect(explanation).toBe(
         '<strong>Real Time:</strong> 1 second of real time = 1 second of game time'
       );
     });
 
-    it('should explain 2x speed correctly', () => {
+    it('explains 2x speed', () => {
       const explanation = generateRatioExplanation(2.0);
       expect(explanation).toBe(
         '<strong>Accelerated Time:</strong> 1 second of real time = 2 seconds of game time (2x speed)'
       );
     });
 
-    it('should explain 0.5x speed correctly', () => {
+    it('explains 0.5x speed', () => {
       const explanation = generateRatioExplanation(0.5);
       expect(explanation).toBe(
         '<strong>Slow Time:</strong> 2 seconds of real time = 1 second of game time'
       );
     });
 
-    it('should explain very slow speed correctly', () => {
+    it('explains very slow speed', () => {
       const explanation = generateRatioExplanation(0.01);
       expect(explanation).toBe(
         '<strong>Very Slow Time:</strong> 2 minutes of real time = 1 second of game time'
       );
     });
 
-    it('should explain fractional speeds correctly', () => {
+    it('explains fractional speeds', () => {
       const explanation = generateRatioExplanation(1.5);
       expect(explanation).toBe(
         '<strong>Accelerated Time:</strong> 1 second of real time = 1.5 seconds of game time (1.5x speed)'
@@ -71,48 +49,44 @@ describe('Time Advancement Ratio Explanations', () => {
     });
   });
 
-  describe('Interval Explanations', () => {
-    it('should explain 1:1 ratio interval correctly', () => {
-      const interval = Math.max(10000, Math.ceil(1000 / 1.0)); // 10000ms
+  describe('Interval explanations', () => {
+    it('explains 1:1 ratio interval', () => {
+      const interval = calculateOptimalInterval(1.0);
       const explanation = generateIntervalExplanation(1.0, interval);
       expect(explanation).toBe('Technical: Every 10 seconds, game time advances by 10 seconds');
     });
 
-    it('should explain 2x speed interval correctly', () => {
-      const interval = Math.max(10000, Math.ceil(1000 / 2.0)); // 10000ms (minimum)
+    it('explains 2x speed interval', () => {
+      const interval = calculateOptimalInterval(2.0);
       const explanation = generateIntervalExplanation(2.0, interval);
       expect(explanation).toBe('Technical: Every 10 seconds, game time advances by 20 seconds');
     });
 
-    it('should explain slow speed interval correctly', () => {
-      const interval = Math.max(10000, Math.ceil(1000 / 0.5)); // 10000ms
+    it('explains slow speed interval', () => {
+      const interval = calculateOptimalInterval(0.5);
       const explanation = generateIntervalExplanation(0.5, interval);
       expect(explanation).toBe('Technical: Every 10 seconds, game time advances by 5 seconds');
     });
   });
 
-  describe('Smart Interval Calculation', () => {
-    function calculateOptimalInterval(ratio: number): number {
-      return Math.max(10000, Math.ceil(1000 / ratio));
-    }
-
-    it('should calculate correct interval for 1:1 ratio', () => {
+  describe('Smart interval calculation', () => {
+    it('calculates 1:1 ratio interval', () => {
       expect(calculateOptimalInterval(1.0)).toBe(10000);
     });
 
-    it('should calculate correct interval for 0.5 ratio (slow)', () => {
+    it('calculates 0.5 ratio interval', () => {
       expect(calculateOptimalInterval(0.5)).toBe(10000);
     });
 
-    it('should calculate correct interval for 2.0 ratio (fast)', () => {
+    it('calculates 2.0 ratio interval', () => {
       expect(calculateOptimalInterval(2.0)).toBe(10000);
     });
 
-    it('should enforce minimum interval of 10000ms', () => {
+    it('enforces minimum interval', () => {
       expect(calculateOptimalInterval(100.0)).toBe(10000);
     });
 
-    it('should calculate correct interval for very slow ratios', () => {
+    it('calculates very slow interval', () => {
       expect(calculateOptimalInterval(0.1)).toBe(10000);
     });
   });

--- a/packages/core/test/time-advancement-service.test.ts
+++ b/packages/core/test/time-advancement-service.test.ts
@@ -250,8 +250,11 @@ describe('TimeAdvancementService', () => {
       vi.useFakeTimers();
 
       mockGame.settings.get.mockImplementation((module: string, key: string) => {
-        if (key === 'pauseOnCombat') return true;
-        return key === 'timeAdvancementRatio' ? 1.0 : false;
+        const settings: Record<string, any> = {
+          timeAdvancementRatio: 1.0,
+          pauseOnCombat: true,
+        };
+        return settings[key];
       });
 
       await service.play();
@@ -272,8 +275,11 @@ describe('TimeAdvancementService', () => {
       vi.useFakeTimers();
 
       mockGame.settings.get.mockImplementation((module: string, key: string) => {
-        if (key === 'pauseOnCombat') return false;
-        return key === 'timeAdvancementRatio' ? 1.0 : false;
+        const settings: Record<string, any> = {
+          timeAdvancementRatio: 1.0,
+          pauseOnCombat: false,
+        };
+        return settings[key];
       });
 
       await service.play();
@@ -366,8 +372,11 @@ describe('TimeAdvancementService', () => {
 
     it('should not attempt resume for non-GMs even with setting enabled', async () => {
       mockGame.settings.get.mockImplementation((module: string, key: string) => {
-        if (key === 'resumeAfterCombat') return true;
-        return key === 'timeAdvancementRatio' ? 1.0 : false;
+        const settings: Record<string, any> = {
+          timeAdvancementRatio: 1.0,
+          resumeAfterCombat: true,
+        };
+        return settings[key];
       });
 
       // Set user as non-GM
@@ -386,8 +395,11 @@ describe('TimeAdvancementService', () => {
 
     it('should allow pause for all users during combat start', async () => {
       mockGame.settings.get.mockImplementation((module: string, key: string) => {
-        if (key === 'pauseOnCombat') return true;
-        return key === 'timeAdvancementRatio' ? 1.0 : false;
+        const settings: Record<string, any> = {
+          timeAdvancementRatio: 1.0,
+          pauseOnCombat: true,
+        };
+        return settings[key];
       });
 
       // Start time advancement first

--- a/packages/fantasy-pack/test/AGENTS.md
+++ b/packages/fantasy-pack/test/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/fantasy-pack/test/CLAUDE.md
+++ b/packages/fantasy-pack/test/CLAUDE.md
@@ -1,0 +1,10 @@
+# Test Suite Guidelines
+
+- Each test file targets a single source module or workflow.
+- No conditional logic (`if`, `switch`, ternary operations, or optional chaining for control flow`).
+- Use deterministic data; avoid random values or relative dates.
+- Assertions must be explicit and exact (`expect(x).toBe(2)`).
+- Prefer exercising real functionality and data over mocks whenever feasible.
+- Unit tests isolate one source file; integration and regression tests cover complete workflows with separate scenarios per test.
+- Keep tests self-contained with no external state.
+- Before committing, run `npm run lint`, `npm run typecheck`, `npm run test:run`, and `npm run build`.

--- a/packages/pf2e-pack/test/AGENTS.md
+++ b/packages/pf2e-pack/test/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/pf2e-pack/test/CLAUDE.md
+++ b/packages/pf2e-pack/test/CLAUDE.md
@@ -1,0 +1,10 @@
+# Test Suite Guidelines
+
+- Each test file targets a single source module or workflow.
+- No conditional logic (`if`, `switch`, ternary operations, or optional chaining for control flow`).
+- Use deterministic data; avoid random values or relative dates.
+- Assertions must be explicit and exact (`expect(x).toBe(2)`).
+- Prefer exercising real functionality and data over mocks whenever feasible.
+- Unit tests isolate one source file; integration and regression tests cover complete workflows with separate scenarios per test.
+- Keep tests self-contained with no external state.
+- Before committing, run `npm run lint`, `npm run typecheck`, `npm run test:run`, and `npm run build`.

--- a/packages/scifi-pack/test/AGENTS.md
+++ b/packages/scifi-pack/test/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/packages/scifi-pack/test/CLAUDE.md
+++ b/packages/scifi-pack/test/CLAUDE.md
@@ -1,0 +1,10 @@
+# Test Suite Guidelines
+
+- Each test file targets a single source module or workflow.
+- No conditional logic (`if`, `switch`, ternary operations, or optional chaining for control flow`).
+- Use deterministic data; avoid random values or relative dates.
+- Assertions must be explicit and exact (`expect(x).toBe(2)`).
+- Prefer exercising real functionality and data over mocks whenever feasible.
+- Unit tests isolate one source file; integration and regression tests cover complete workflows with separate scenarios per test.
+- Keep tests self-contained with no external state.
+- Before committing, run `npm run lint`, `npm run typecheck`, `npm run test:run`, and `npm run build`.


### PR DESCRIPTION
## Summary
- export settings preview explanation helpers for direct testing without branching
- replace conditional mock settings in time advancement service tests with explicit maps

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c65ba9fdc88327aa1170ee456da5e7