### PR TITLE
feat(core): add movable mini widget with pinning

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A calendar and timekeeping module for Foundry VTT v13+ with clean integration AP
 - **Smart Year Navigation**: Click year to jump instantly instead of clicking arrows repeatedly
 - **Convenient Defaults**: Gregorian calendars can initialize with current date/time
 - **Module Integration**: Clean APIs for weather modules and other integrations via compatibility bridges
-- **SmallTime Integration**: Seamless positioning and visual consistency. Time display intelligently hidden when SmallTime is present (configurable)
+- **SmallTime Integration**: Seamless positioning and visual consistency. Time display intelligently hidden when SmallTime is present (configurable). Mini widget provides drag-and-drop positioning with persistent storage.
 - **16 Available Calendars**: Switch between core calendars (Gregorian, Golarion PF2e) and calendar pack collections featuring fantasy calendars (D&D, Critical Role, etc.), sci-fi calendars (Star Trek, Starfinder, Traveller), and custom formats based on official game sources
 - **Calendar Pack Auto-Detection**: Automatically discovers and loads calendar modules following the `seasons-and-stars-*` naming convention - no JavaScript required, just JSON data files
 - **External Calendar Registration**: New hook system (v0.8.0+) allows modules to register calendars programmatically for dynamic calendar loading

--- a/README_FOUNDRY.md
+++ b/README_FOUNDRY.md
@@ -67,7 +67,7 @@ _Note: This is an alpha release. Testing has been focused on D&D 5e, Pathfinder 
 
 ### **SmallTime**
 
-The mini widget is designed to position alongside SmallTime for complementary time display.
+The mini widget automatically positions alongside SmallTime and supports drag-and-drop positioning with persistent storage.
 
 ### **Simple Weather**
 

--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -698,6 +698,12 @@ integration.widgets.main?.addSidebarButton('weather', 'fas fa-cloud', 'Weather',
   console.log('Weather button clicked');
 });
 
+// Mini widget supports drag-and-drop positioning
+// Position is automatically saved when users drag the widget
+// Right-click to unpin and return to automatic positioning
+integration.widgets.mini?.show(); // Show mini widget
+integration.widgets.mini?.toggle(); // Toggle mini widget visibility
+
 // Hook system
 integration.hooks.onDateChanged(event => {
   console.log('Date changed:', event.newDate);

--- a/docs/MIGRATION-GUIDE.md
+++ b/docs/MIGRATION-GUIDE.md
@@ -17,40 +17,47 @@ A comprehensive guide for migrating from Simple Calendar to Seasons & Stars, cov
 ### Benefits of Seasons & Stars
 
 #### ✅ **Modern Architecture**
+
 - **Foundry v13+ Native**: Built specifically for latest Foundry versions
 - **ApplicationV2**: Modern UI framework with better performance
 - **TypeScript**: Better code quality and developer experience
 - **Clean Codebase**: Easier to maintain and extend
 
 #### ✅ **Better User Experience**
+
 - **Intuitive Interface**: Cleaner, more responsive UI
 - **Smart Navigation**: Click year to jump instantly (no more 1000+ clicks)
 - **SmallTime Integration**: Seamless positioning and visual consistency
 - **Real-World Initialization**: Gregorian calendars start with today's date
 
 #### ✅ **Enhanced Compatibility**
+
 - **Automatic Detection**: Works alongside existing modules without conflicts
 - **Backward Compatibility**: Existing Simple Calendar integrations work immediately
 - **Future-Proof**: Active development with modern best practices
 
 #### ✅ **Performance Improvements**
+
 - **Faster Calculations**: Optimized calendar math and caching
 - **Responsive UI**: Better handling of large date ranges
 - **Memory Efficient**: Cleaner resource management
 
 ### Migration Timeline
 
-#### **Phase 1** ✅ *Available Now*
+#### **Phase 1** ✅ _Available Now_
+
 - Core calendar functionality
 - Simple Calendar API compatibility
 - Basic weather module support
 
-#### **Phase 2** 🚧 *Q1 2025*
+#### **Phase 2** 🚧 _Q1 2025_
+
 - Complete notes system
 - Full weather module compatibility
 - Advanced configuration options
 
-#### **Phase 3** 📅 *Q2 2025*
+#### **Phase 3** 📅 _Q2 2025_
+
 - Automated migration tools
 - Calendar editor
 - Enhanced theming
@@ -60,19 +67,23 @@ A comprehensive guide for migrating from Simple Calendar to Seasons & Stars, cov
 ### Pre-Migration Checklist
 
 #### 1. **Backup Your World**
+
 ```bash
 # Always backup before major changes
 # Foundry automatically creates backups, but manual backup recommended
 ```
 
 #### 2. **Document Current Setup**
+
 - Note your current calendar system (Gregorian, Harptos, etc.)
 - Export any critical calendar events/notes
 - List weather modules and other calendar integrations
 - Screenshot current calendar settings
 
 #### 3. **Check Module Compatibility**
+
 Review your modules for calendar dependencies:
+
 - Weather modules (Simple Weather, etc.)
 - Time-tracking modules
 - Custom calendar modules
@@ -80,59 +91,69 @@ Review your modules for calendar dependencies:
 ### Migration Steps
 
 #### Step 1: Install Seasons & Stars
+
 1. **Install Module**: Search for "Seasons & Stars" in Foundry module browser
 2. **Keep Simple Calendar**: Don't disable it yet - they can coexist during testing
 3. **Enable S&S**: Activate Seasons & Stars in your world
 4. **Test Basic Functions**: Verify calendar appears and works
 
 #### Step 1.5: Install Simple Calendar Compatibility Bridge (If Needed)
+
 **Required if you use:**
+
 - Weather modules (Simple Weather, etc.)
 - Other modules that depend on Simple Calendar API
 - Custom modules that call `window.SimpleCalendar` methods
 
 **Installation:**
+
 1. **Install Bridge Module**: Search for "Simple Calendar Compatibility Bridge" in Foundry module browser
 2. **Enable Bridge**: Activate the compatibility bridge in your world
 3. **Verify Compatibility**: Check that dependent modules continue working
 4. **Important**: Do NOT run both the bridge and Simple Calendar together
 
 #### Step 2: Configure Calendar System
+
 1. **Select Calendar**: Choose matching calendar type (Gregorian → Gregorian, Harptos → Vale Reckoning)
 2. **Set Current Date**: Use grid view to set correct current date
 3. **Verify Time Display**: Check that dates and times display correctly
 4. **Test Time Advancement**: Try advancing time with quick buttons
 
 #### Step 3: Test Module Compatibility
+
 1. **Weather Modules**: Verify weather updates work with date changes
 2. **Custom Modules**: Test any modules that use calendar functions
 3. **Player Experience**: Have players test calendar visibility and interaction
 
 #### Step 4: Gradual Transition
+
 1. **Parallel Operation**: Run both systems for a few sessions
 2. **Monitor Issues**: Watch for any problems or conflicts
 3. **Player Feedback**: Get input from your table
 4. **Feature Comparison**: Note any missing features you need
 
 #### Step 5: Complete Migration
+
 1. **Disable Simple Calendar**: Once confident, disable the old module
 2. **Clean Up**: Remove Simple Calendar if no longer needed
 3. **Update Documentation**: Inform players about the change
-4. **Configure Widgets**: Set up mini widget and positioning preferences
+4. **Configure Widgets**: Set up mini widget and positioning preferences. The mini widget now supports drag-and-drop positioning with automatic save/restore.
 
 ### Calendar System Mapping
 
 #### **Simple Calendar → Seasons & Stars**
-| Simple Calendar | Seasons & Stars | Notes |
-|----------------|----------------|-------|
-| Gregorian | Gregorian | Direct match |
-| Harptos | Vale Reckoning | Similar fantasy calendar |
-| Golarian (PF) | Custom calendar | Import JSON when available |
-| Exandrian | Custom calendar | Import JSON when available |
-| Eberron | Custom calendar | Import JSON when available |
-| Custom calendars | Custom import | Phase 3 feature |
+
+| Simple Calendar  | Seasons & Stars | Notes                      |
+| ---------------- | --------------- | -------------------------- |
+| Gregorian        | Gregorian       | Direct match               |
+| Harptos          | Vale Reckoning  | Similar fantasy calendar   |
+| Golarian (PF)    | Custom calendar | Import JSON when available |
+| Exandrian        | Custom calendar | Import JSON when available |
+| Eberron          | Custom calendar | Import JSON when available |
+| Custom calendars | Custom import   | Phase 3 feature            |
 
 #### **Date Format Changes**
+
 ```javascript
 // Simple Calendar uses 0-based months/days
 const scDate = { year: 2024, month: 11, day: 24 }; // December 25th
@@ -144,6 +165,7 @@ const ssDate = { year: 2024, month: 12, day: 25 }; // December 25th
 ### Feature Comparison
 
 #### ✅ **Available in Seasons & Stars**
+
 - ✅ Multiple calendar systems
 - ✅ Time advancement controls
 - ✅ Date/time display
@@ -153,12 +175,14 @@ const ssDate = { year: 2024, month: 12, day: 25 }; // December 25th
 - ✅ Year navigation (improved!)
 
 #### 🚧 **Coming Soon (Phase 2)**
+
 - 🚧 Notes/events system
 - 🚧 Complete weather module support
 - 🚧 Calendar configuration UI
 - 🚧 Import/export tools
 
 #### ❌ **Not Planned**
+
 - ❌ Built-in weather generation
 - ❌ Combat time integration
 - ❌ PF2E world clock sync
@@ -166,12 +190,14 @@ const ssDate = { year: 2024, month: 12, day: 25 }; // December 25th
 ### Settings Migration
 
 #### **Simple Calendar Settings**
+
 ```javascript
 // Export your current settings before migration
 console.log(game.settings.get('foundryvtt-simple-calendar', 'calendar-configuration'));
 ```
 
 #### **Seasons & Stars Settings**
+
 - **Active Calendar**: Choose calendar system
 - **Show Time Widget**: Toggle mini widget
 - **Time Format**: Configure display options
@@ -181,37 +207,42 @@ console.log(game.settings.get('foundryvtt-simple-calendar', 'calendar-configurat
 ### Compatibility Assessment
 
 #### **Immediate Compatibility** ✅
+
 Your module likely works immediately if it uses:
+
 - `SimpleCalendar.api.currentDateTime()`
 - `SimpleCalendar.api.timestampToDate()`
 - `SimpleCalendar.Hooks.DateTimeChange`
 - Basic calendar data access
 
 #### **Needs Updates** 🔄
+
 Your module needs changes if it uses:
+
 - Simple Calendar's notes system (Phase 2)
 - Advanced configuration APIs
 - Calendar creation functions
 - Internal Simple Calendar structures
 
 #### **Testing Your Module**
+
 ```javascript
 // Test compatibility detection
 function testCalendarCompatibility() {
   console.log('=== Calendar System Detection ===');
-  
+
   // Check for Seasons & Stars
   if (game.seasonsStars) {
     console.log('✅ Seasons & Stars detected');
     console.log('API available:', !!game.seasonsStars.api);
   }
-  
+
   // Check for Simple Calendar compatibility
   if (window.SimpleCalendar) {
     console.log('✅ SimpleCalendar API available');
     console.log('Is compatibility layer:', !!window.SimpleCalendar._isSeasonsStarsCompatibility);
   }
-  
+
   // Test critical functions
   try {
     const currentDate = SimpleCalendar.api.currentDateTime();
@@ -219,7 +250,7 @@ function testCalendarCompatibility() {
   } catch (e) {
     console.error('❌ currentDateTime() failed:', e);
   }
-  
+
   try {
     const timestampDate = SimpleCalendar.api.timestampToDate(game.time.worldTime);
     console.log('✅ timestampToDate() works:', timestampDate);
@@ -233,6 +264,7 @@ function testCalendarCompatibility() {
 ### Migration Strategies
 
 #### Strategy 1: Universal Adapter (Recommended)
+
 Create an adapter that works with multiple calendar systems:
 
 ```javascript
@@ -241,7 +273,7 @@ class CalendarAdapter {
     this.type = this.detectCalendarType();
     this.setupHooks();
   }
-  
+
   detectCalendarType() {
     if (game.seasonsStars && !window.SimpleCalendar._isSeasonsStarsCompatibility) {
       return 'seasons-stars';
@@ -253,7 +285,7 @@ class CalendarAdapter {
       return 'none';
     }
   }
-  
+
   getCurrentDate() {
     switch (this.type) {
       case 'seasons-stars':
@@ -265,7 +297,7 @@ class CalendarAdapter {
         return null;
     }
   }
-  
+
   setupHooks() {
     switch (this.type) {
       case 'seasons-stars':
@@ -281,6 +313,7 @@ class CalendarAdapter {
 ```
 
 #### Strategy 2: Gradual Migration
+
 Migrate in phases as features become available:
 
 ```javascript
@@ -289,7 +322,7 @@ class WeatherManager {
   constructor() {
     this.useCompatibilityAPI();
   }
-  
+
   useCompatibilityAPI() {
     // Current approach - works with both systems
     if (window.SimpleCalendar) {
@@ -297,7 +330,7 @@ class WeatherManager {
       Hooks.on(SimpleCalendar.Hooks.DateTimeChange, this.onDateChange.bind(this));
     }
   }
-  
+
   // Phase 2: Migrate to native API when notes system available
   migrateToNativeAPI() {
     if (game.seasonsStars) {
@@ -310,6 +343,7 @@ class WeatherManager {
 ```
 
 #### Strategy 3: Feature Detection
+
 Use feature detection instead of system detection:
 
 ```javascript
@@ -318,16 +352,16 @@ class AdvancedCalendarIntegration {
     this.features = this.detectFeatures();
     this.setupBasedOnFeatures();
   }
-  
+
   detectFeatures() {
     return {
       hasDateTimeAPI: typeof SimpleCalendar?.api?.currentDateTime === 'function',
       hasNotesAPI: typeof SimpleCalendar?.api?.addNote === 'function',
       hasAdvancedFormatting: typeof game.seasonsStars?.api?.formatDate === 'function',
-      hasNativeHooks: !!game.seasonsStars
+      hasNativeHooks: !!game.seasonsStars,
     };
   }
-  
+
   setupBasedOnFeatures() {
     if (this.features.hasNativeHooks) {
       // Use native Seasons & Stars hooks for better performance
@@ -343,32 +377,35 @@ class AdvancedCalendarIntegration {
 ### Testing Your Migration
 
 #### Unit Tests
+
 ```javascript
 // Test calendar API compatibility
 describe('Calendar Integration', () => {
   it('should get current date from any calendar system', () => {
     const adapter = new CalendarAdapter();
     const currentDate = adapter.getCurrentDate();
-    
+
     expect(currentDate).toBeDefined();
     expect(currentDate.year).toBeGreaterThan(0);
     expect(currentDate.month).toBeGreaterThan(0);
   });
-  
-  it('should handle date changes', (done) => {
+
+  it('should handle date changes', done => {
     const adapter = new CalendarAdapter();
-    
-    adapter.onDateChange = (data) => {
+
+    adapter.onDateChange = data => {
       expect(data).toBeDefined();
       done();
     };
-    
+
     // Trigger a date change
     if (game.seasonsStars) {
       game.seasonsStars.api.advanceDays(1);
     } else if (SimpleCalendar) {
       SimpleCalendar.api.changeDate({
-        year: 2024, month: 11, day: 25
+        year: 2024,
+        month: 11,
+        day: 25,
       });
     }
   });
@@ -376,26 +413,31 @@ describe('Calendar Integration', () => {
 ```
 
 #### Integration Tests
+
 ```javascript
 // Test with real calendar systems
 async function testRealIntegration() {
   console.log('=== Real Integration Test ===');
-  
+
   // Test getting current weather
   const currentDate = SimpleCalendar.api.currentDateTime();
   const weather = generateWeatherForDate(currentDate);
   console.log('Current weather:', weather);
-  
+
   // Test advancing time
   const originalTime = game.time.worldTime;
   await SimpleCalendar.api.changeDate({
-    year: 2024, month: 11, day: 25,
-    hour: 12, minute: 0, second: 0
+    year: 2024,
+    month: 11,
+    day: 25,
+    hour: 12,
+    minute: 0,
+    second: 0,
   });
-  
+
   const newDate = SimpleCalendar.api.currentDateTime();
   console.log('Date change successful:', newDate);
-  
+
   // Restore original time
   await game.time.advance(originalTime - game.time.worldTime);
 }
@@ -406,34 +448,36 @@ async function testRealIntegration() {
 ### Exporting Simple Calendar Data
 
 #### Configuration Export
+
 ```javascript
 // Export Simple Calendar settings
 function exportSimpleCalendarConfig() {
   const config = game.settings.get('foundryvtt-simple-calendar', 'calendar-configuration');
   const notes = game.settings.get('foundryvtt-simple-calendar', 'notes');
-  
+
   const exportData = {
     timestamp: Date.now(),
     foundryVersion: game.version,
     simpleCalendarVersion: game.modules.get('foundryvtt-simple-calendar')?.version,
     config: config,
-    notes: notes
+    notes: notes,
   };
-  
+
   const dataStr = JSON.stringify(exportData, null, 2);
   const blob = new Blob([dataStr], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
-  
+
   const a = document.createElement('a');
   a.href = url;
   a.download = `simple-calendar-export-${Date.now()}.json`;
   a.click();
-  
+
   URL.revokeObjectURL(url);
 }
 ```
 
 #### Notes Export
+
 ```javascript
 // Export calendar notes/events
 function exportCalendarNotes() {
@@ -447,10 +491,10 @@ function exportCalendarNotes() {
       date: note.date,
       categories: note.categories,
       author: note.author,
-      playerVisible: note.playerVisible
-    }))
+      playerVisible: note.playerVisible,
+    })),
   };
-  
+
   // Save to file
   const dataStr = JSON.stringify(exportData, null, 2);
   const blob = new Blob([dataStr], { type: 'application/json' });
@@ -461,24 +505,26 @@ function exportCalendarNotes() {
 ### Importing to Seasons & Stars
 
 #### Phase 1: Manual Import
+
 ```javascript
 // Convert Simple Calendar date format to Seasons & Stars format
 function convertDateFormat(scDate) {
   return {
     year: scDate.year,
     month: scDate.month + 1, // Convert from 0-based to 1-based
-    day: scDate.day + 1,     // Convert from 0-based to 1-based
+    day: scDate.day + 1, // Convert from 0-based to 1-based
     weekday: scDate.weekday,
     time: {
       hour: scDate.hour || 0,
       minute: scDate.minute || 0,
-      second: scDate.second || 0
-    }
+      second: scDate.second || 0,
+    },
   };
 }
 ```
 
 #### Phase 2: Automated Import (Future)
+
 ```javascript
 // Automated migration tool (Phase 3)
 class MigrationTool {
@@ -487,7 +533,7 @@ class MigrationTool {
     const ssData = this.convertToSeasonsStarsFormat(scData);
     await this.importToSeasonsStars(ssData);
   }
-  
+
   convertCalendarConfiguration(scConfig) {
     // Convert calendar definitions
     // Map notes and events
@@ -500,42 +546,43 @@ class MigrationTool {
 
 ### Module Compatibility Status
 
-| Module | Status | Notes |
-|--------|--------|-------|
-| **Simple Weather** | ✅ Compatible | Works with compatibility layer |
-| **Calendar/Weather** | ✅ Compatible | Basic functions work |
-| **About Time** | ⚠️ Partial | Time controls work, advanced features TBD |
-| **SmallTime** | ✅ Enhanced | Better integration than SC |
-| **Monks Little Details** | ✅ Compatible | Time display works |
-| **Custom Weather** | ⚠️ Needs Testing | Depends on implementation |
+| Module                   | Status           | Notes                                     |
+| ------------------------ | ---------------- | ----------------------------------------- |
+| **Simple Weather**       | ✅ Compatible    | Works with compatibility layer            |
+| **Calendar/Weather**     | ✅ Compatible    | Basic functions work                      |
+| **About Time**           | ⚠️ Partial       | Time controls work, advanced features TBD |
+| **SmallTime**            | ✅ Enhanced      | Better integration than SC                |
+| **Monks Little Details** | ✅ Compatible    | Time display works                        |
+| **Custom Weather**       | ⚠️ Needs Testing | Depends on implementation                 |
 
 ### API Compatibility
 
-| Simple Calendar API | Status | Notes |
-|---------------------|--------|-------|
-| `currentDateTime()` | ✅ Full | Direct compatibility |
-| `timestampToDate()` | ✅ Full | Includes display object |
-| `changeDate()` | ✅ Full | Format conversion included |
-| `getAllMonths()` | ✅ Full | Calendar data access |
-| `getAllWeekdays()` | ✅ Full | Calendar data access |
-| `addNote()` | 🚧 Phase 2 | Placeholder returns false |
-| `getNotes()` | 🚧 Phase 2 | Returns empty array |
-| `formatDateTime()` | ✅ Basic | Limited formatting options |
+| Simple Calendar API | Status     | Notes                      |
+| ------------------- | ---------- | -------------------------- |
+| `currentDateTime()` | ✅ Full    | Direct compatibility       |
+| `timestampToDate()` | ✅ Full    | Includes display object    |
+| `changeDate()`      | ✅ Full    | Format conversion included |
+| `getAllMonths()`    | ✅ Full    | Calendar data access       |
+| `getAllWeekdays()`  | ✅ Full    | Calendar data access       |
+| `addNote()`         | 🚧 Phase 2 | Placeholder returns false  |
+| `getNotes()`        | 🚧 Phase 2 | Returns empty array        |
+| `formatDateTime()`  | ✅ Basic   | Limited formatting options |
 
 ### Hook Compatibility
 
-| Simple Calendar Hook | Seasons & Stars Equivalent | Status |
-|-----------------------|----------------------------|--------|
-| `DateTimeChange` | `seasons-stars:dateChanged` | ✅ Mapped |
-| `Ready` | `seasons-stars:ready` | ✅ Mapped |
-| `ClockStartStop` | Not applicable | ❌ Not implemented |
-| `PrimaryGM` | Not applicable | ❌ Not needed |
+| Simple Calendar Hook | Seasons & Stars Equivalent  | Status             |
+| -------------------- | --------------------------- | ------------------ |
+| `DateTimeChange`     | `seasons-stars:dateChanged` | ✅ Mapped          |
+| `Ready`              | `seasons-stars:ready`       | ✅ Mapped          |
+| `ClockStartStop`     | Not applicable              | ❌ Not implemented |
+| `PrimaryGM`          | Not applicable              | ❌ Not needed      |
 
 ## 🔧 Troubleshooting
 
 ### Common Issues
 
 #### **Calendar Not Appearing**
+
 ```javascript
 // Debug checklist
 console.log('Seasons & Stars loaded:', !!game.seasonsStars);
@@ -544,12 +591,14 @@ console.log('Settings registered:', !!game.settings.get('seasons-and-stars', 'ac
 ```
 
 **Solutions:**
+
 1. Refresh browser after enabling module
 2. Check for JavaScript errors in console
 3. Verify Foundry v13+ requirement
 4. Disable conflicting UI modules temporarily
 
 #### **Weather Module Not Working**
+
 ```javascript
 // Test compatibility layer
 console.log('SimpleCalendar available:', !!window.SimpleCalendar);
@@ -558,12 +607,14 @@ console.log('timestampToDate test:', SimpleCalendar.api.timestampToDate(game.tim
 ```
 
 **Solutions:**
+
 1. Ensure Simple Calendar is disabled (conflict)
 2. Check that weather module is loading after Seasons & Stars
 3. Verify weather module uses standard SC API
 4. Test with compatibility test page
 
 #### **Date Format Issues**
+
 ```javascript
 // Check date format conversion
 const scDate = SimpleCalendar.api.currentDateTime();
@@ -574,17 +625,21 @@ console.log('SS format (1-based):', ssDate);
 ```
 
 **Solutions:**
+
 1. Module may be using internal SC format - needs update
 2. Check if module handles date format conversion
 3. Use compatibility layer instead of direct access
 
 #### **Performance Issues**
+
 **Symptoms:**
+
 - Slow date calculations
 - UI lag when changing dates
 - Memory usage increases
 
 **Solutions:**
+
 1. Disable Simple Calendar if both are running
 2. Clear browser cache and restart Foundry
 3. Check for infinite loops in date change handlers
@@ -593,6 +648,7 @@ console.log('SS format (1-based):', ssDate);
 ### Debugging Tools
 
 #### **Compatibility Test Console Commands**
+
 ```javascript
 // Test API availability
 game.seasonsStars ? console.log('✅ Seasons & Stars') : console.log('❌ Seasons & Stars');
@@ -602,7 +658,7 @@ window.SimpleCalendar ? console.log('✅ SimpleCalendar API') : console.log('❌
 try {
   const date = SimpleCalendar.api.currentDateTime();
   console.log('✅ currentDateTime:', date);
-} catch(e) {
+} catch (e) {
   console.log('❌ currentDateTime failed:', e.message);
 }
 
@@ -610,12 +666,13 @@ try {
 try {
   const formatted = SimpleCalendar.api.timestampToDate(game.time.worldTime);
   console.log('✅ Formatted date:', formatted.display);
-} catch(e) {
+} catch (e) {
   console.log('❌ timestampToDate failed:', e.message);
 }
 ```
 
 #### **Hook Testing**
+
 ```javascript
 // Test hook system
 let hookReceived = false;
@@ -648,6 +705,7 @@ Your support helps fund new features, bug fixes, and comprehensive documentation
 ### If Migration Fails
 
 #### **Immediate Rollback**
+
 1. **Disable Seasons & Stars**: Turn off in module management
 2. **Re-enable Simple Calendar**: Activate previous module
 3. **Restore Settings**: Simple Calendar settings should be preserved
@@ -655,6 +713,7 @@ Your support helps fund new features, bug fixes, and comprehensive documentation
 5. **Test Modules**: Ensure weather modules work again
 
 #### **Data Recovery**
+
 ```javascript
 // Check if Simple Calendar data is intact
 const scConfig = game.settings.get('foundryvtt-simple-calendar', 'calendar-configuration');
@@ -665,7 +724,9 @@ console.log('SC Notes preserved:', !!scNotes);
 ```
 
 #### **Reporting Issues**
+
 If you need to rollback, please report:
+
 1. **Error Messages**: Console errors and warnings
 2. **Module List**: All active modules and versions
 3. **Use Case**: What you were trying to accomplish
@@ -682,11 +743,15 @@ function checkCalendarPriority() {
   console.log('=== Calendar System Priority ===');
   console.log('Seasons & Stars active:', !!game.seasonsStars);
   console.log('Simple Calendar active:', !!game.modules.get('foundryvtt-simple-calendar')?.active);
-  console.log('SimpleCalendar API source:', window.SimpleCalendar?._isSeasonsStarsCompatibility ? 'Seasons & Stars' : 'Simple Calendar');
+  console.log(
+    'SimpleCalendar API source:',
+    window.SimpleCalendar?._isSeasonsStarsCompatibility ? 'Seasons & Stars' : 'Simple Calendar'
+  );
 }
 ```
 
 **Best Practices for Coexistence:**
+
 1. Test with low-stakes world first
 2. Keep detailed notes of any issues
 3. Have players test basic calendar functions

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -85,7 +85,9 @@ A compact calendar companion that works alongside SmallTime.
 
 - **With SmallTime**: Appears above SmallTime automatically
 - **Without SmallTime**: Positions near player list
-- **Responsive**: Adapts to UI changes and window resizing
+- **Draggable**: Drag the widget to any position to pin it in place
+- **Persistent**: Pinned positions are saved and restored when the world reloads
+- **Responsive**: Adapts to UI changes and window resizing when not pinned
 
 ### 3. Monthly Grid View
 
@@ -479,11 +481,12 @@ When SmallTime is enabled:
 
 ### Manual Configuration
 
-If automatic positioning doesn't work:
+The mini widget now provides drag-and-drop positioning:
 
-1. Disable auto-positioning in settings
-2. Use CSS to manually position the mini widget
-3. Or disable the mini widget and use only the full calendar
+1. **Drag to Position**: Simply drag the mini widget anywhere on screen to pin it
+2. **Right-click to Unpin**: Right-click the widget to return to automatic positioning
+3. **Persistent Storage**: Pinned positions are automatically saved and restored
+4. **Fallback**: If needed, disable the mini widget and use only the full calendar
 
 ### Without SmallTime
 
@@ -530,10 +533,11 @@ Your support helps fund new features, bug fixes, and comprehensive documentation
 
 **Solution:**
 
-1. Try refreshing the page
-2. Toggle the widget off and on in settings
-3. Check for UI module conflicts
-4. Use manual positioning if needed
+1. **Drag and Pin**: Simply drag the mini widget to your preferred position - it will automatically pin and remember the location
+2. **Unpin**: Right-click the widget to unpin and return to automatic positioning
+3. Try refreshing the page if positioning seems incorrect
+4. Toggle the widget off and on in settings if needed
+5. Check for UI module conflicts with other positioning systems
 
 #### SmallTime Integration Problems
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9700,7 +9700,7 @@
     },
     "packages/core": {
       "name": "seasons-and-stars",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -453,6 +453,22 @@ function registerSettings(): void {
     },
   });
 
+  game.settings.register('seasons-and-stars', 'miniWidgetPosition', {
+    name: 'Mini Widget Position',
+    scope: 'client',
+    config: false,
+    type: Object,
+    default: { top: null, left: null },
+  });
+
+  game.settings.register('seasons-and-stars', 'miniWidgetPinned', {
+    name: 'Mini Widget Pinned',
+    scope: 'client',
+    config: false,
+    type: Boolean,
+    default: false,
+  });
+
   game.settings.register('seasons-and-stars', 'miniWidgetCanonicalMode', {
     name: 'Canonical Hours Display Mode',
     hint: 'How to display time when canonical hours are available: Auto (canonical hours when available, exact time otherwise), Canonical Only (hide time when no canonical hour), or Exact Time (always show exact time)',

--- a/packages/core/src/types/foundry-extensions.d.ts
+++ b/packages/core/src/types/foundry-extensions.d.ts
@@ -16,6 +16,23 @@ import type { LoadResult, ExternalCalendarSource } from '../core/calendar-loader
 
 // Extend the Game interface to include S&S specific properties
 declare global {
+  namespace foundry {
+    namespace applications {
+      namespace ux {
+        class Draggable {
+          constructor(
+            app: any,
+            element: HTMLElement,
+            handle: HTMLElement | false,
+            resizable: boolean | any
+          );
+          activateListeners(): void;
+          _onDragMouseDown(event: MouseEvent): any;
+          _onDragMouseUp(event: MouseEvent): any;
+        }
+      }
+    }
+  }
   interface String {
     stripScripts(): string;
   }

--- a/packages/core/src/types/foundry-extensions.d.ts
+++ b/packages/core/src/types/foundry-extensions.d.ts
@@ -18,6 +18,44 @@ import type { LoadResult, ExternalCalendarSource } from '../core/calendar-loader
 declare global {
   namespace foundry {
     namespace applications {
+      namespace api {
+        class ApplicationV2 {
+          constructor(options?: any);
+
+          element?: HTMLElement;
+          position: {
+            top?: number;
+            left?: number;
+            width?: number | string;
+            height?: number | string;
+            scale?: number;
+          };
+          rendered: boolean;
+
+          // Core lifecycle methods
+          render(force?: boolean): Promise<void>;
+          close(options?: any): Promise<any>;
+
+          // Protected lifecycle hooks
+          protected _onRender(context: any, options: any): void;
+          protected _prepareContext(options: any): any;
+          protected _attachPartListeners(
+            partId: string,
+            htmlElement: HTMLElement,
+            options: any
+          ): void;
+
+          // Static properties
+          static DEFAULT_OPTIONS: any;
+          static PARTS: any;
+        }
+
+        function HandlebarsApplicationMixin<T extends typeof ApplicationV2>(BaseApplication: T): T;
+
+        class DialogV2 extends ApplicationV2 {
+          // DialogV2 specific properties if needed
+        }
+      }
       namespace ux {
         class Draggable {
           constructor(
@@ -31,6 +69,11 @@ declare global {
           _onDragMouseUp(event: MouseEvent): any;
         }
       }
+    }
+
+    namespace utils {
+      function mergeObject(original: any, other: any, options?: any): any;
+      function deepClone(obj: any): any;
     }
   }
   interface String {

--- a/packages/core/src/ui/calendar-mini-widget.ts
+++ b/packages/core/src/ui/calendar-mini-widget.ts
@@ -26,9 +26,6 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
       | { top: number; left: number }
       | undefined;
 
-    Logger.debug(`Mini widget: Constructor - pinned: ${pinned}, position:`, pos);
-    Logger.debug(`Mini widget: Constructor - incoming options:`, options);
-
     // If pinned and we have a valid position, apply it to options
     if (
       pinned &&
@@ -38,22 +35,15 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
       Number.isFinite(pos.top) &&
       Number.isFinite(pos.left)
     ) {
-      Logger.debug(
-        `Mini widget: Constructor - applying pinned position top=${pos.top}, left=${pos.left}`
-      );
       options = (foundry.utils as any).mergeObject(options, {
         position: {
           top: pos.top,
           left: pos.left,
         },
       });
-      Logger.debug(`Mini widget: Constructor - merged options:`, options);
     }
 
     super(options);
-
-    // Check what position ApplicationV2 actually received
-    Logger.debug(`Mini widget: Constructor - ApplicationV2 position after super():`, this.position);
   }
 
   static DEFAULT_OPTIONS = {
@@ -315,13 +305,6 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
     });
 
     const pinned = game.settings?.get('seasons-and-stars', 'miniWidgetPinned');
-    Logger.debug(`Mini widget: _onRender - pinned status: ${pinned}`);
-    Logger.debug(`Mini widget: _onRender - ApplicationV2 position:`, this.position);
-    Logger.debug(`Mini widget: _onRender - element position before positioning:`, {
-      position: this.element?.style.position,
-      top: this.element?.style.top,
-      left: this.element?.style.left,
-    });
 
     if (pinned) {
       this.applyPinnedPosition();
@@ -379,23 +362,12 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
   private applyPinnedPosition(): void {
     if (!this.element) return;
 
-    Logger.debug('Mini widget: Applying pinned position styling');
-    Logger.debug('Mini widget: ApplicationV2 position:', this.position);
-    Logger.debug('Mini widget: Element position before applying ApplicationV2 position:', {
-      position: this.element.style.position,
-      top: this.element.style.top,
-      left: this.element.style.left,
-    });
-
     // ApplicationV2 has the position but doesn't automatically apply it to the DOM
     // We need to manually apply the position from ApplicationV2's position property
     if (this.position.top !== undefined && this.position.left !== undefined) {
       this.element.style.position = 'fixed';
       this.element.style.top = `${this.position.top}px`;
       this.element.style.left = `${this.position.left}px`;
-      Logger.debug(
-        `Mini widget: Applied ApplicationV2 position - top=${this.position.top}, left=${this.position.left}`
-      );
     }
 
     // Apply the visual styling for pinned mode
@@ -407,12 +379,6 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
       'below-smalltime',
       'beside-smalltime'
     );
-
-    Logger.debug('Mini widget: Element position after applying position and styling:', {
-      position: this.element.style.position,
-      top: this.element.style.top,
-      left: this.element.style.left,
-    });
 
     this.hasBeenPositioned = true;
   }
@@ -452,7 +418,6 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
 
       // Apply pinned styling and save position
       const rect = this.app.element.getBoundingClientRect();
-      Logger.debug(`Mini widget: Drag end - saving position top=${rect.top}, left=${rect.left}`);
 
       this.app.element.style.zIndex = WIDGET_POSITIONING.Z_INDEX.toString();
       this.app.element.classList.add('standalone-mode');
@@ -469,12 +434,6 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
         left: rect.left,
       });
 
-      Logger.debug(`Mini widget: Position saved to settings`);
-
-      // Verify the position was actually applied
-      const savedPos = game.settings?.get('seasons-and-stars', 'miniWidgetPosition');
-      Logger.debug(`Mini widget: Verified saved position:`, savedPos);
-
       return result;
     };
   }
@@ -483,7 +442,6 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
    * Unpin the widget and reset to automatic positioning
    */
   private async unpin(): Promise<void> {
-    Logger.debug('Mini widget: Unpinning and resetting to automatic positioning');
     await game.settings?.set('seasons-and-stars', 'miniWidgetPinned', false);
     await game.settings?.set('seasons-and-stars', 'miniWidgetPosition', {
       top: null,

--- a/packages/core/test/mini-widget-pinned-position.test.ts
+++ b/packages/core/test/mini-widget-pinned-position.test.ts
@@ -7,6 +7,21 @@ import { CalendarMiniWidget } from '../src/ui/calendar-mini-widget';
 
 const mockSettings = new Map();
 
+// Mock foundry.utils for mergeObject
+(global as any).foundry = {
+  utils: {
+    mergeObject: (original: any, other: any) => ({ ...original, ...other }),
+  },
+  applications: {
+    ux: {
+      Draggable: vi.fn().mockImplementation(() => ({
+        _onDragMouseDown: vi.fn(),
+        _onDragMouseUp: vi.fn(),
+      })),
+    },
+  },
+};
+
 global.game = {
   settings: {
     get: vi.fn((module: string, key: string) => mockSettings.get(`${module}.${key}`)),
@@ -40,89 +55,46 @@ describe('Mini Widget Pinned Positioning', () => {
   });
 
   it('applies stored position when pinned', () => {
+    // Set up ApplicationV2 position property (mock)
+    (widget as any).position = { top: 100, left: 50 };
+
     (widget as any).applyPinnedPosition();
     const element = widget.element as HTMLElement;
     expect(element.style.top).toBe('100px');
     expect(element.style.left).toBe('50px');
+    expect(element.style.position).toBe('fixed');
+    expect(element.classList.contains('standalone-mode')).toBe(true);
   });
 
-  it('does not pin on simple click without movement', async () => {
-    mockSettings.set('seasons-and-stars.miniWidgetPinned', false);
-    mockSettings.set('seasons-and-stars.miniWidgetPosition', { top: null, left: null });
+  it('sets up dragging with Foundry Draggable class', () => {
     const element = widget.element as HTMLElement;
-    Object.assign(element, {
-      getBoundingClientRect: () =>
-        ({
-          top: 100,
-          left: 100,
-          bottom: 150,
-          right: 150,
-          width: 50,
-          height: 50,
-          x: 100,
-          y: 100,
-          toJSON: () => ({}),
-        }) as DOMRect,
-    });
 
-    (widget as any).enableDrag();
+    // Verify setupDragging method completes without errors
+    expect(() => {
+      (widget as any).setupDragging();
+    }).not.toThrow();
 
-    element.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 110, clientY: 120 }));
-    document.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 110, clientY: 120 }));
-
-    await Promise.resolve();
-
-    expect(mockSettings.get('seasons-and-stars.miniWidgetPinned')).toBe(false);
-    expect(mockSettings.get('seasons-and-stars.miniWidgetPosition')).toEqual({
-      top: null,
-      left: null,
-    });
+    // Verify Draggable constructor was called
+    expect((global as any).foundry.applications.ux.Draggable).toHaveBeenCalledWith(
+      widget, // app
+      element, // element
+      element, // handle
+      false // resizable
+    );
   });
 
-  it('pins and stores coordinates after dragging beyond threshold', async () => {
-    mockSettings.set('seasons-and-stars.miniWidgetPinned', false);
-    mockSettings.set('seasons-and-stars.miniWidgetPosition', { top: null, left: null });
+  it('skips positioning when ApplicationV2 position is undefined', () => {
+    // Set up ApplicationV2 position property as undefined (no stored position)
+    (widget as any).position = { top: undefined, left: undefined };
     const element = widget.element as HTMLElement;
-    Object.assign(element, {
-      getBoundingClientRect: () =>
-        ({
-          top: 100,
-          left: 100,
-          bottom: 150,
-          right: 150,
-          width: 50,
-          height: 50,
-          x: 100,
-          y: 100,
-          toJSON: () => ({}),
-        }) as DOMRect,
-    });
-
-    (widget as any).enableDrag();
-
-    element.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 110, clientY: 120 }));
-    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 160, clientY: 190 }));
-    document.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 160, clientY: 190 }));
-
-    await Promise.resolve();
-    await Promise.resolve();
-
-    expect(mockSettings.get('seasons-and-stars.miniWidgetPinned')).toBe(true);
-    expect(mockSettings.get('seasons-and-stars.miniWidgetPosition')).toEqual({
-      top: 170,
-      left: 150,
-    });
-    const elementStyles = widget.element as HTMLElement;
-    expect(elementStyles.classList.contains('standalone-mode')).toBe(true);
-    expect((widget as any).hasBeenPositioned).toBe(true);
-  });
-
-  it('falls back to automatic positioning when stored coordinates are invalid', () => {
-    mockSettings.set('seasons-and-stars.miniWidgetPosition', { top: Number.NaN, left: Number.NaN });
-    const positionSpy = vi.spyOn(widget as any, 'positionWidget').mockImplementation(() => {});
 
     (widget as any).applyPinnedPosition();
 
-    expect(positionSpy).toHaveBeenCalledTimes(1);
+    // Should not set position styles when position is undefined
+    expect(element.style.top).toBe('');
+    expect(element.style.left).toBe('');
+    expect(element.style.position).toBe('');
+    // But should still apply the styling classes
+    expect(element.classList.contains('standalone-mode')).toBe(true);
   });
 });

--- a/packages/core/test/mini-widget-pinned-position.test.ts
+++ b/packages/core/test/mini-widget-pinned-position.test.ts
@@ -30,6 +30,7 @@ describe('Mini Widget Pinned Positioning', () => {
   let widget: CalendarMiniWidget;
 
   beforeEach(() => {
+    vi.clearAllMocks();
     mockSettings.clear();
     mockSettings.set('seasons-and-stars.miniWidgetPinned', true);
     mockSettings.set('seasons-and-stars.miniWidgetPosition', { top: 100, left: 50 });
@@ -43,5 +44,85 @@ describe('Mini Widget Pinned Positioning', () => {
     const element = widget.element as HTMLElement;
     expect(element.style.top).toBe('100px');
     expect(element.style.left).toBe('50px');
+  });
+
+  it('does not pin on simple click without movement', async () => {
+    mockSettings.set('seasons-and-stars.miniWidgetPinned', false);
+    mockSettings.set('seasons-and-stars.miniWidgetPosition', { top: null, left: null });
+    const element = widget.element as HTMLElement;
+    Object.assign(element, {
+      getBoundingClientRect: () =>
+        ({
+          top: 100,
+          left: 100,
+          bottom: 150,
+          right: 150,
+          width: 50,
+          height: 50,
+          x: 100,
+          y: 100,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    });
+
+    (widget as any).enableDrag();
+
+    element.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 110, clientY: 120 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 110, clientY: 120 }));
+
+    await Promise.resolve();
+
+    expect(mockSettings.get('seasons-and-stars.miniWidgetPinned')).toBe(false);
+    expect(mockSettings.get('seasons-and-stars.miniWidgetPosition')).toEqual({
+      top: null,
+      left: null,
+    });
+  });
+
+  it('pins and stores coordinates after dragging beyond threshold', async () => {
+    mockSettings.set('seasons-and-stars.miniWidgetPinned', false);
+    mockSettings.set('seasons-and-stars.miniWidgetPosition', { top: null, left: null });
+    const element = widget.element as HTMLElement;
+    Object.assign(element, {
+      getBoundingClientRect: () =>
+        ({
+          top: 100,
+          left: 100,
+          bottom: 150,
+          right: 150,
+          width: 50,
+          height: 50,
+          x: 100,
+          y: 100,
+          toJSON: () => ({}),
+        }) as DOMRect,
+    });
+
+    (widget as any).enableDrag();
+
+    element.dispatchEvent(new MouseEvent('mousedown', { button: 0, clientX: 110, clientY: 120 }));
+    document.dispatchEvent(new MouseEvent('mousemove', { clientX: 160, clientY: 190 }));
+    document.dispatchEvent(new MouseEvent('mouseup', { button: 0, clientX: 160, clientY: 190 }));
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockSettings.get('seasons-and-stars.miniWidgetPinned')).toBe(true);
+    expect(mockSettings.get('seasons-and-stars.miniWidgetPosition')).toEqual({
+      top: 170,
+      left: 150,
+    });
+    const elementStyles = widget.element as HTMLElement;
+    expect(elementStyles.classList.contains('standalone-mode')).toBe(true);
+    expect((widget as any).hasBeenPositioned).toBe(true);
+  });
+
+  it('falls back to automatic positioning when stored coordinates are invalid', () => {
+    mockSettings.set('seasons-and-stars.miniWidgetPosition', { top: Number.NaN, left: Number.NaN });
+    const positionSpy = vi.spyOn(widget as any, 'positionWidget').mockImplementation(() => {});
+
+    (widget as any).applyPinnedPosition();
+
+    expect(positionSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/test/mini-widget-pinned-position.test.ts
+++ b/packages/core/test/mini-widget-pinned-position.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Tests for mini widget pinned positioning
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { CalendarMiniWidget } from '../src/ui/calendar-mini-widget';
+
+const mockSettings = new Map();
+
+global.game = {
+  settings: {
+    get: vi.fn((module: string, key: string) => mockSettings.get(`${module}.${key}`)),
+    set: vi.fn((module: string, key: string, value: unknown) => {
+      mockSettings.set(`${module}.${key}`, value);
+      return Promise.resolve();
+    }),
+  },
+  user: { isGM: true },
+  seasonsStars: {} as any,
+} as any;
+
+vi.mock('../src/ui/base-widget-manager', () => ({
+  SmallTimeUtils: {
+    isSmallTimeAvailable: () => false,
+    getSmallTimeElement: () => null,
+  },
+}));
+
+describe('Mini Widget Pinned Positioning', () => {
+  let widget: CalendarMiniWidget;
+
+  beforeEach(() => {
+    mockSettings.clear();
+    mockSettings.set('seasons-and-stars.miniWidgetPinned', true);
+    mockSettings.set('seasons-and-stars.miniWidgetPosition', { top: 100, left: 50 });
+
+    widget = new CalendarMiniWidget();
+    (widget as any).element = document.createElement('div');
+  });
+
+  it('applies stored position when pinned', () => {
+    (widget as any).applyPinnedPosition();
+    const element = widget.element as HTMLElement;
+    expect(element.style.top).toBe('100px');
+    expect(element.style.left).toBe('50px');
+  });
+});

--- a/packages/core/test/ui/calendar-mini-widget.test.ts
+++ b/packages/core/test/ui/calendar-mini-widget.test.ts
@@ -50,6 +50,21 @@ vi.mock('../../src/ui/calendar-selection-dialog', () => ({
   })),
 }));
 
+// Mock foundry.utils and Draggable
+(global as any).foundry = {
+  utils: {
+    mergeObject: (original: any, other: any) => ({ ...original, ...other }),
+  },
+  applications: {
+    ux: {
+      Draggable: vi.fn().mockImplementation(() => ({
+        _onDragMouseDown: vi.fn(),
+        _onDragMouseUp: vi.fn(),
+      })),
+    },
+  },
+};
+
 describe('CalendarMiniWidget', () => {
   let widget: CalendarMiniWidget;
   let mockCalendar: SeasonsStarsCalendar;


### PR DESCRIPTION
## Summary
- allow mini widget to be moved and pinned like SmallTime
- fall back to lower-left when SmallTime and player list are hidden
- cover pinned positioning with unit test

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test:run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7a323b998832792a36c1a58102330