### PR TITLE
docs: note simple calendar bridge coordination

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,24 @@
 - Refer to the GitHub Action config in `.github/workflows/semantic-pull-request.yml` for allowed commit message types and scopes.
 - Releases are automated with [release-please](https://github.com/googleapis/release-please); do not manually edit version numbers or `CHANGELOG.md`.
 
+### Simple Calendar Compatibility Bridge Coordination
+
+- **Coordinate early:** When planning any Seasons & Stars API change, notify the maintainers of the [Simple Calendar Compatibility Bridge](https://github.com/rayners/foundryvtt-simple-calendar-compat) and link to the tracking issue/PR in both repositories.
+- **What counts as an API change?** Treat the following as externally consumed surfaces that require Bridge validation:
+  - Hook events documented in `docs/DEVELOPER-GUIDE.md` or exposed through `Hooks.call`/`Hooks.callAll`.
+  - Exported TypeScript definitions, interfaces, or enums under `packages/core/src/types/` and any symbols re-exported from package entry points.
+  - Public methods on `CalendarManager`, `CalendarEngine`, `BridgeIntegration`, or other classes referenced in integration guides.
+  - JSON contracts passed between the compatibility layer and downstream modules (e.g., note payloads, time advancement messages).
+- **Examples that require coordination:**
+  - Renaming or removing a hook such as `seasons-and-stars.calendarUpdated` or changing its payload structure.
+  - Adding mandatory parameters to `BridgeIntegration` methods or modifying the Simple Calendar translation tables.
+  - Changing the schema of exported interfaces like `CalendarDateData` that compatibility bridges deserialize.
+- **Process checklist:**
+  1. Open or update an issue in the Bridge repository describing the required adjustments and reference the Seasons & Stars PR.
+  2. Provide migration notes or a draft PR for the Bridge when feasible so dependent modules can test pre-release builds.
+  3. Call out the coordination requirement in the Seasons & Stars changelog or release notes once the work lands.
+- **Automation:** We are evaluating a GitHub Action that diffs exported symbols and hook declarations to flag potential API changes automatically. Until it lands, rely on manual review and err on the side of coordinating even “minor” tweaks.
+
 ## Module Architecture Deep Dive
 
 ### Calendar Engine Core (packages/core/src/core/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,6 +251,33 @@ npm run test:watch    # Run tests in watch mode
 npm run coverage      # Generate coverage report
 ```
 
+## Simple Calendar Compatibility Bridge Coordination
+
+Maintaining parity with the [Simple Calendar Compatibility Bridge](https://github.com/rayners/foundryvtt-simple-calendar-compat) keeps downstream modules functioning when we evolve the Seasons & Stars API.
+
+### When to Coordinate
+
+- Changes to documented hook names, payloads, or invocation timing.
+- Updates to exported TypeScript interfaces, enums, or helper types under `packages/core/src/types/` (including re-exports from package entry points).
+- Signature or behavior changes for public classes that integrators touch, such as `CalendarManager`, `CalendarEngine`, `BridgeIntegration`, and other APIs highlighted in `docs/DEVELOPER-GUIDE.md` and `docs/INTEGRATION-GUIDE.md`.
+- Adjustments to JSON structures passed between the bridge and external modules (note payloads, time advancement messages, integration metadata, etc.).
+
+### Examples Requiring Bridge Updates
+
+- Removing or renaming hooks like `seasons-and-stars.calendarUpdated` or altering the shape of their payload objects.
+- Adding new required parameters to bridge translation utilities or changing default behaviors that Simple Calendar expects.
+- Refactoring exported types such as `CalendarDateData` or `BridgeRegistrationConfig` in a way that breaks existing consumers.
+
+### Coordination Checklist
+
+1. Open or update an issue in the Bridge repository describing the planned change and link to the Seasons & Stars PR.
+2. Provide migration guidance or a draft PR for the Bridge when feasible so dependent module authors can test against the update.
+3. Reference the bridge coordination in release notes or changelog entries to keep the community informed.
+
+### Automation Outlook
+
+We are exploring a GitHub Action that monitors exported symbols and hook declarations to automatically flag potential API changes. Until that lands, treat manual coordination as mandatory for any change that might affect the bridge.
+
 ## Documentation
 
 ### Code Documentation

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -8,3 +8,5 @@ Follow the repository guidelines in the [root CLAUDE.md](../../CLAUDE.md):
 - Version numbers and changelogs are managed by release-please; avoid editing them manually.
 
 Additional CLAUDE.md files in subdirectories may offer more specific instructions.
+
+When making any changes to the exposed Seasons & Stars API (including hooks, TypeScript definitions, or externally consumed integration points), ensure the [Simple Calendar Compatibility Bridge](https://github.com/rayners/foundryvtt-simple-calendar-compat) module is kept in sync. Coordinate updates with that repository and file or update a tracking issue there so downstream users are aware of the required compatibility work.


### PR DESCRIPTION
## Summary
- add a core CLAUDE guideline to coordinate API changes with the Simple Calendar Compatibility Bridge repository

## Testing
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9bb8052bc8327a00fcd2a4fd544a5