### PR TITLE
feat: align Golarion leap cycle with lore

### DIFF
--- a/CALENDAR-FORMAT.md
+++ b/CALENDAR-FORMAT.md
@@ -39,6 +39,7 @@ disable leap years entirely, include `"leapYear": { "rule": "none" }`.
   "leapYear": {
     "rule": "none",
     "interval": 4,
+    "offset": 0,
     "month": "February",
     "extraDays": 1
   },
@@ -610,6 +611,7 @@ For calendars with lunar cycles, add moon definitions with phase tracking:
 ### Cross-References
 
 - `leapYear.month`: Must match a month name
+- `leapYear.offset`: Optional number indicating how many years to subtract before applying the interval rule (defaults to 0)
 - `intercalary[].after`: Must match a month name
 - All month and weekday names must be unique within their arrays
 

--- a/CALENDAR-FORMAT.md
+++ b/CALENDAR-FORMAT.md
@@ -158,6 +158,7 @@ disable leap years entirely, include `"leapYear": { "rule": "none" }`.
 | ----------- | ------ | ------- | ---------------------------------------------------- |
 | `rule`      | string | "none"  | Leap year calculation: "none", "gregorian", "custom" |
 | `interval`  | number | 4       | For custom rules: leap year every N years            |
+| `offset`    | number | 0       | Optional year offset before applying the interval    |
 | `month`     | string | -       | Which month receives extra days                      |
 | `extraDays` | number | 1       | How many extra days in leap years                    |
 
@@ -166,6 +167,7 @@ disable leap years entirely, include `"leapYear": { "rule": "none" }`.
 - `"none"`: No leap years
 - `"gregorian"`: Standard Gregorian calendar rules (every 4 years, except centuries not divisible by 400)
 - `"custom"`: Simple interval-based (every N years)
+- `offset`: Shift the starting point of the custom cycle (e.g., `interval: 8` and `offset: 4` leap on years 4, 12, 20, ...)
 
 ### Month Definitions
 

--- a/packages/core/src/core/calendar-engine.ts
+++ b/packages/core/src/core/calendar-engine.ts
@@ -917,7 +917,7 @@ export class CalendarEngine {
     const leapYear = this.calendar.leapYear;
     if (!leapYear) return false;
 
-    const { rule, interval } = leapYear;
+    const { rule, interval, offset = 0 } = leapYear;
 
     switch (rule) {
       case 'none':
@@ -927,7 +927,10 @@ export class CalendarEngine {
         return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
 
       case 'custom':
-        return interval ? year % interval === 0 : false;
+        if (!interval) return false;
+        const normalizedYear = year - offset;
+        const remainder = normalizedYear % interval;
+        return (remainder + interval) % interval === 0;
 
       default:
         return false;

--- a/packages/core/src/core/calendar-engine.ts
+++ b/packages/core/src/core/calendar-engine.ts
@@ -1029,31 +1029,61 @@ export class CalendarEngine {
         : daysSinceReference +
           Math.ceil(Math.abs(daysSinceReference) / moon.cycleLength) * moon.cycleLength;
 
-    // Calculate position in current cycle
-    const dayInCycle = adjustedDays % moon.cycleLength;
+    // Calculate position in current cycle with tolerance for fractional lengths
+    const cyclePositionRaw =
+      ((adjustedDays % moon.cycleLength) + moon.cycleLength) % moon.cycleLength;
+    const phaseBoundaryTolerance = 1e-6;
 
-    // Find current phase
+    let phaseStart = 0;
     let currentPhaseIndex = 0;
-    let daysIntoPhase = dayInCycle;
 
     for (let i = 0; i < moon.phases.length; i++) {
-      if (daysIntoPhase < moon.phases[i].length) {
+      const phase = moon.phases[i];
+      const phaseEnd = phaseStart + phase.length;
+
+      if (cyclePositionRaw < phaseEnd - phaseBoundaryTolerance || i === moon.phases.length - 1) {
         currentPhaseIndex = i;
         break;
       }
-      daysIntoPhase -= moon.phases[i].length;
+
+      phaseStart = phaseEnd;
     }
 
     const currentPhase = moon.phases[currentPhaseIndex];
-    const daysUntilNext = currentPhase.length - daysIntoPhase;
+    const rawDayInPhase = cyclePositionRaw - phaseStart;
+    const normalizedDayInPhase = Math.max(this.normalizeFractionalValue(rawDayInPhase), 0);
+    const phaseLength = currentPhase.length;
+    const dayInPhaseExact = Math.min(normalizedDayInPhase, phaseLength);
+    const rawDaysUntilNext = phaseLength - dayInPhaseExact;
+    const daysUntilNextExact = Math.max(this.normalizeFractionalValue(rawDaysUntilNext), 0);
+    const phaseProgress =
+      phaseLength > 0 ? Math.min(Math.max(dayInPhaseExact / phaseLength, 0), 1) : 0;
 
     return {
       moon,
       phase: currentPhase,
       phaseIndex: currentPhaseIndex,
-      dayInPhase: Math.floor(daysIntoPhase),
-      daysUntilNext: Math.ceil(daysUntilNext),
+      dayInPhase: Math.floor(dayInPhaseExact),
+      dayInPhaseExact,
+      daysUntilNext: Math.max(Math.ceil(daysUntilNextExact), 0),
+      daysUntilNextExact,
+      phaseProgress,
     };
+  }
+
+  private normalizeFractionalValue(value: number): number {
+    const precision = 1_000_000;
+    const rounded = Math.round(value * precision) / precision;
+
+    if (rounded === 0) {
+      return 0;
+    }
+
+    if (!Number.isFinite(rounded)) {
+      return 0;
+    }
+
+    return rounded;
   }
 
   /**

--- a/packages/core/src/core/calendar-engine.ts
+++ b/packages/core/src/core/calendar-engine.ts
@@ -926,11 +926,14 @@ export class CalendarEngine {
       case 'gregorian':
         return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
 
-      case 'custom':
+      case 'custom': {
         if (!interval) return false;
         const normalizedYear = year - offset;
         const remainder = normalizedYear % interval;
-        return (remainder + interval) % interval === 0;
+        // Check if the year is divisible by the interval.
+        // For negative remainders, we need to normalize them to positive values.
+        return remainder === 0 || (remainder < 0 && remainder + interval === 0);
+      }
 
       default:
         return false;

--- a/packages/core/src/types/calendar.d.ts
+++ b/packages/core/src/types/calendar.d.ts
@@ -33,6 +33,10 @@ export interface SeasonsStarsCalendar {
   leapYear: {
     rule: 'none' | 'gregorian' | 'custom';
     interval?: number;
+    /**
+     * Optional base-year shift applied before evaluating the interval.
+     * Allows lore-specific rules such as "every 8 years starting with 4708 AR".
+     */
     offset?: number;
     month?: string;
     extraDays?: number;

--- a/packages/core/src/types/calendar.d.ts
+++ b/packages/core/src/types/calendar.d.ts
@@ -33,6 +33,7 @@ export interface SeasonsStarsCalendar {
   leapYear: {
     rule: 'none' | 'gregorian' | 'custom';
     interval?: number;
+    offset?: number;
     month?: string;
     extraDays?: number;
   };

--- a/packages/core/src/types/calendar.d.ts
+++ b/packages/core/src/types/calendar.d.ts
@@ -170,7 +170,10 @@ export interface MoonPhaseInfo {
   phase: MoonPhase;
   phaseIndex: number;
   dayInPhase: number;
+  dayInPhaseExact: number;
   daysUntilNext: number;
+  daysUntilNextExact: number;
+  phaseProgress: number;
 }
 
 export interface CalendarCanonicalHour {

--- a/packages/core/src/types/external-integrations.d.ts
+++ b/packages/core/src/types/external-integrations.d.ts
@@ -291,6 +291,9 @@ export interface CalendarDayData {
     moonColor?: string;
     dayInPhase: number;
     daysUntilNext: number;
+    dayInPhaseExact?: number;
+    daysUntilNextExact?: number;
+    phaseProgress?: number;
   }>;
   primaryMoonPhase?: string; // Icon for the primary/first moon
   primaryMoonColor?: string; // Color for the primary/first moon

--- a/packages/core/test/calendar-engine.test.ts
+++ b/packages/core/test/calendar-engine.test.ts
@@ -106,6 +106,24 @@ describe('CalendarValidator', () => {
     expect(result.errors).toHaveLength(0);
   });
 
+  it('should accept custom leap year offsets', async () => {
+    const offsetCalendar: SeasonsStarsCalendar = {
+      ...simpleCalendar,
+      id: 'custom-offset',
+      leapYear: {
+        rule: 'custom',
+        interval: 8,
+        offset: 4,
+        month: 'Month1',
+        extraDays: 1,
+      },
+    };
+
+    const result = await CalendarValidator.validate(offsetCalendar);
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
   it('should reject invalid calendar', async () => {
     const invalid = { id: 'test' }; // Missing required fields
     const result = await CalendarValidator.validate(invalid);

--- a/packages/core/test/calendar-engine.test.ts
+++ b/packages/core/test/calendar-engine.test.ts
@@ -124,6 +124,24 @@ describe('CalendarValidator', () => {
     expect(result.errors).toHaveLength(0);
   });
 
+  it('should accept negative leap year offsets', async () => {
+    const negativeOffsetCalendar: SeasonsStarsCalendar = {
+      ...simpleCalendar,
+      id: 'negative-offset',
+      leapYear: {
+        rule: 'custom',
+        interval: 6,
+        offset: -2,
+        month: 'Month2',
+        extraDays: 1,
+      },
+    };
+
+    const result = await CalendarValidator.validate(negativeOffsetCalendar);
+    expect(result.isValid).toBe(true);
+    expect(result.errors).toHaveLength(0);
+  });
+
   it('should reject invalid calendar', async () => {
     const invalid = { id: 'test' }; // Missing required fields
     const result = await CalendarValidator.validate(invalid);

--- a/packages/core/test/moon-phase-tracking.test.ts
+++ b/packages/core/test/moon-phase-tracking.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { CalendarEngine } from '../src/core/calendar-engine';
 import { CalendarDate } from '../src/core/calendar-date';
-import type { SeasonsStarsCalendar, CalendarMoon } from '../src/types/calendar';
+import type { SeasonsStarsCalendar } from '../src/types/calendar';
 
 describe('Moon Phase Tracking', () => {
   let testCalendar: SeasonsStarsCalendar;
@@ -384,6 +384,7 @@ describe('Moon Phase Tracking', () => {
       const moonPhases = engine.getMoonPhaseInfo(newMoonDate);
 
       expect(moonPhases[0].daysUntilNext).toBe(1); // Should be 1 day until waxing crescent starts
+      expect(moonPhases[0].daysUntilNextExact).toBeCloseTo(1, 6);
     });
 
     it('should provide accurate day in phase', () => {
@@ -401,6 +402,9 @@ describe('Moon Phase Tracking', () => {
 
       expect(moonPhases[0].phase.name).toBe('Waxing Crescent');
       expect(moonPhases[0].dayInPhase).toBe(1); // Second day of waxing crescent phase
+      expect(moonPhases[0].dayInPhaseExact).toBeCloseTo(1, 6);
+      expect(moonPhases[0].daysUntilNextExact).toBeCloseTo(5.3826475, 6);
+      expect(moonPhases[0].phaseProgress).toBeCloseTo(1 / 6.3826475, 6);
     });
   });
 
@@ -413,7 +417,7 @@ describe('Moon Phase Tracking', () => {
         { month: 3, day: 11, expectedPhase: 'New Moon' }, // March 11, 2024 - approximately two cycles later (30 days)
       ];
 
-      lunarDates.forEach(({ month, day, expectedPhase }) => {
+      lunarDates.forEach(({ month, day }) => {
         const date = new CalendarDate(
           {
             year: 2024,

--- a/packages/core/test/worldtime-edge-cases-comprehensive.test.ts
+++ b/packages/core/test/worldtime-edge-cases-comprehensive.test.ts
@@ -134,12 +134,12 @@ describe('WorldTime Edge Cases - Comprehensive Test Suite', () => {
     test('Handle leap year boundaries with worldTime conversion', () => {
       // Test leap day and surrounding dates
       const leapYearTests = [
-        { year: 2024, month: 2, day: 28, description: 'Day before leap day' },
-        { year: 2024, month: 2, day: 29, description: 'Leap day itself' },
-        { year: 2024, month: 3, day: 1, description: 'Day after leap day' },
+        { year: 4724, month: 2, day: 28, description: 'Day before leap day' },
+        { year: 4724, month: 2, day: 29, description: 'Leap day itself' },
+        { year: 4724, month: 3, day: 1, description: 'Day after leap day' },
         // Non-leap year for comparison
-        { year: 2023, month: 2, day: 28, description: 'Feb 28 in non-leap year' },
-        { year: 2023, month: 3, day: 1, description: 'Mar 1 in non-leap year' },
+        { year: 4723, month: 2, day: 28, description: 'Feb 28 in non-leap year' },
+        { year: 4723, month: 3, day: 1, description: 'Mar 1 in non-leap year' },
       ];
 
       leapYearTests.forEach(testDate => {
@@ -155,7 +155,7 @@ describe('WorldTime Edge Cases - Comprehensive Test Suite', () => {
             expect(roundTrip.month).toBe(testDate.month);
             expect(roundTrip.day).toBe(testDate.day);
           } catch (error) {
-            if (testDate.month === 2 && testDate.day === 29 && testDate.year === 2023) {
+            if (testDate.month === 2 && testDate.day === 29 && testDate.year === 4723) {
               // Feb 29, 2023 doesn't exist (not a leap year) - error expected
               expect(error).toBeDefined();
             } else {

--- a/packages/pf2e-pack/calendars/golarion-pf2e.json
+++ b/packages/pf2e-pack/calendars/golarion-pf2e.json
@@ -3,7 +3,7 @@
   "translations": {
     "en": {
       "label": "Golarion Calendar (Pathfinder 2e)",
-      "description": "The Absalom Reckoning calendar system used throughout Golarion, the campaign setting for Pathfinder Second Edition. Features twelve months with leap years following Gregorian rules.",
+      "description": "The Absalom Reckoning calendar system used throughout Golarion, the campaign setting for Pathfinder Second Edition. Features twelve months, Somal's synodic lunar cycle, and the traditional eight-year leap year pattern.",
       "setting": "Pathfinder 2e"
     }
   },
@@ -26,11 +26,13 @@
     "currentYear": 4725,
     "prefix": "",
     "suffix": " AR",
-    "startDay": 6
+    "startDay": 4
   },
 
   "leapYear": {
-    "rule": "gregorian",
+    "rule": "custom",
+    "interval": 8,
+    "offset": 4,
     "month": "Calistril",
     "extraDays": 1
   },
@@ -153,22 +155,42 @@
   "moons": [
     {
       "name": "Somal",
-      "cycleLength": 28,
-      "firstNewMoon": { "year": 4725, "month": 1, "day": 7 },
+      "cycleLength": 29.53059,
+      "firstNewMoon": { "year": 4713, "month": 1, "day": 11 },
       "phases": [
         { "name": "New Moon", "length": 1, "singleDay": true, "icon": "new" },
-        { "name": "Waxing Crescent", "length": 6, "singleDay": false, "icon": "waxing-crescent" },
+        {
+          "name": "Waxing Crescent",
+          "length": 6.3826475,
+          "singleDay": false,
+          "icon": "waxing-crescent"
+        },
         { "name": "First Quarter", "length": 1, "singleDay": true, "icon": "first-quarter" },
-        { "name": "Waxing Gibbous", "length": 6, "singleDay": false, "icon": "waxing-gibbous" },
+        {
+          "name": "Waxing Gibbous",
+          "length": 6.3826475,
+          "singleDay": false,
+          "icon": "waxing-gibbous"
+        },
         { "name": "Full Moon", "length": 1, "singleDay": true, "icon": "full" },
-        { "name": "Waning Gibbous", "length": 6, "singleDay": false, "icon": "waning-gibbous" },
+        {
+          "name": "Waning Gibbous",
+          "length": 6.3826475,
+          "singleDay": false,
+          "icon": "waning-gibbous"
+        },
         { "name": "Last Quarter", "length": 1, "singleDay": true, "icon": "last-quarter" },
-        { "name": "Waning Crescent", "length": 6, "singleDay": false, "icon": "waning-crescent" }
+        {
+          "name": "Waning Crescent",
+          "length": 6.3826475,
+          "singleDay": false,
+          "icon": "waning-crescent"
+        }
       ],
       "color": "#d0d0d0",
       "translations": {
         "en": {
-          "description": "Golarion's pale moon, witness to the struggles of mortals and gods alike"
+          "description": "Golarion's pale moon, following the synodic cycle recorded in Blood of the Moon (4713 AR)"
         }
       }
     }
@@ -177,29 +199,29 @@
   "seasons": [
     {
       "name": "Winter",
-      "startMonth": 11,
-      "endMonth": 1,
+      "startMonth": 12,
+      "endMonth": 2,
       "icon": "winter",
       "description": "The cold season when snow blankets much of Golarion's northern regions."
     },
     {
       "name": "Spring",
-      "startMonth": 2,
-      "endMonth": 4,
+      "startMonth": 3,
+      "endMonth": 5,
       "icon": "spring",
       "description": "The season of renewal when Golarion awakens from winter's grip."
     },
     {
       "name": "Summer",
-      "startMonth": 5,
-      "endMonth": 7,
+      "startMonth": 6,
+      "endMonth": 8,
       "icon": "summer",
       "description": "The warm season of growth and exploration across the Inner Sea region."
     },
     {
       "name": "Autumn",
-      "startMonth": 8,
-      "endMonth": 10,
+      "startMonth": 9,
+      "endMonth": 11,
       "icon": "fall",
       "description": "The harvest season as communities prepare for the coming winter."
     }
@@ -286,7 +308,7 @@
 
     "earth-historical": {
       "name": "Earth Historical (AD)",
-      "description": "Earth Anno Domini calendar for modern campaigns and real-world synchronization",
+      "description": "Non-canon Earth Anno Domini calendar for modern campaigns and real-world synchronization",
       "config": {
         "yearOffset": -95
       },

--- a/packages/pf2e-pack/calendars/golarion-pf2e.json
+++ b/packages/pf2e-pack/calendars/golarion-pf2e.json
@@ -3,7 +3,7 @@
   "translations": {
     "en": {
       "label": "Golarion Calendar (Pathfinder 2e)",
-      "description": "The Absalom Reckoning calendar system used throughout Golarion, the campaign setting for Pathfinder Second Edition. Features twelve months, Somal's synodic lunar cycle, and the traditional eight-year leap year pattern.",
+      "description": "The Absalom Reckoning calendar system used throughout Golarion, the campaign setting for Pathfinder Second Edition. Features twelve months, Somal's synodic lunar cycle, and the traditional eight-year leap year pattern. Calistril's extra day appears in years congruent to 4 AR modulo 8 (4708, 4716, 4724, ...), matching Absalom Reckoning almanacs by applying a +4 leap-year offset.",
       "setting": "Pathfinder 2e"
     }
   },

--- a/packages/pf2e-pack/calendars/golarion-pf2e.json
+++ b/packages/pf2e-pack/calendars/golarion-pf2e.json
@@ -3,7 +3,7 @@
   "translations": {
     "en": {
       "label": "Golarion Calendar (Pathfinder 2e)",
-      "description": "The Absalom Reckoning calendar system used throughout Golarion, the campaign setting for Pathfinder Second Edition. Features twelve months, Somal's synodic lunar cycle, and the traditional eight-year leap year pattern. Calistril's extra day appears in years congruent to 4 AR modulo 8 (4708, 4716, 4724, ...), matching Absalom Reckoning almanacs by applying a +4 leap-year offset.",
+      "description": "The Absalom Reckoning calendar system used throughout Golarion, the campaign setting for Pathfinder Second Edition. Features twelve months, Somal's synodic lunar cycle, and the traditional eight-year leap year pattern recognized in Absalom Reckoning almanacs.",
       "setting": "Pathfinder 2e"
     }
   },

--- a/shared/schemas/calendar-v1.0.0.json
+++ b/shared/schemas/calendar-v1.0.0.json
@@ -221,6 +221,12 @@
           "maximum": 1000,
           "description": "For custom rules: interval between leap years"
         },
+        "offset": {
+          "type": "integer",
+          "minimum": -1000,
+          "maximum": 1000,
+          "description": "Optional year offset applied before interval calculation"
+        },
         "month": {
           "type": "string",
           "minLength": 1,
@@ -260,6 +266,19 @@
                 "minimum": 1,
                 "maximum": 10,
                 "description": "How many extra days to add"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["offset"]
+          },
+          "then": {
+            "properties": {
+              "rule": {
+                "const": "custom",
+                "description": "Offsets are only meaningful for custom interval rules"
               }
             }
           }


### PR DESCRIPTION
## Summary
- align the PF2e Golarion calendar with lore by using the eight-year leap cycle, corrected seasonal ranges, and Somal's synodic phase data
- add support for custom leap-year offsets and document the new calendar field
- update world-time regression coverage to exercise the revised leap-year pattern

## Testing
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf90a25e04832790358b9c7d5a7efe