### PR TITLE
fix: remove incorrect month data from Imperial Calendar variant

### DIFF
--- a/packages/pf2e-pack/calendars/golarion-pf2e.json
+++ b/packages/pf2e-pack/calendars/golarion-pf2e.json
@@ -228,27 +228,13 @@
 
     "imperial-calendar": {
       "name": "Imperial Calendar",
-      "description": "Chelish Imperial dating system used in Cheliax and its territories",
+      "description": "Tian Xia Imperial dating system used in the Dragon Empires",
       "config": {
         "yearOffset": 5200
       },
       "overrides": {
         "year": {
           "suffix": " IC"
-        },
-        "months": {
-          "Abadius": {
-            "name": "First Imperial",
-            "description": "The first month of the Imperial calendar, marking the beginning of the fiscal year in Cheliax."
-          },
-          "Calistril": {
-            "name": "Second Imperial",
-            "description": "The second month of the Imperial calendar, often marked by increased devil worship ceremonies."
-          },
-          "Pharast": {
-            "name": "Third Imperial",
-            "description": "The third month of the Imperial calendar, when the Imperial bureaucracy reaches peak activity."
-          }
         }
       }
     },


### PR DESCRIPTION
Fixes #264

## Changes
- Removed incorrect month name overrides (First/Second/Third Imperial) from the Imperial Calendar variant
- Updated description to reference Tian Xia instead of Cheliax
- The Imperial Calendar now uses standard Golarion month names

As noted in the issue, the books don't specify different month names for Tian Xia, so using the standard names is appropriate.

Generated with [Claude Code](https://claude.ai/code)