### PR TITLE
test: improve notes cleanup registration hooks

### DIFF
--- a/packages/core/src/core/calendar-date.ts
+++ b/packages/core/src/core/calendar-date.ts
@@ -10,6 +10,7 @@ import type {
 } from '../types/calendar';
 import { CalendarTimeUtils } from './calendar-time-utils';
 import { DateFormatter } from './date-formatter';
+import { Logger } from './logger';
 
 export class CalendarDate implements ICalendarDate {
   year: number;
@@ -44,7 +45,7 @@ export class CalendarDate implements ICalendarDate {
       this.calendar = calendar;
       this.formatter = new DateFormatter(calendar);
     } catch (error) {
-      console.debug('[S&S] Error creating CalendarDate:', error);
+      Logger.debug('Error creating CalendarDate:', error);
       throw error;
     }
   }
@@ -178,7 +179,7 @@ export class CalendarDate implements ICalendarDate {
         format: 'short',
       });
     } catch (error) {
-      console.debug('[S&S] Error formatting short date string:', error);
+      Logger.debug('Error formatting short date string:', error);
       return `${this.day} ${this.getMonthName('short')} ${this.getYearString()}`;
     }
   }
@@ -212,7 +213,7 @@ export class CalendarDate implements ICalendarDate {
         format: 'long',
       });
     } catch (error) {
-      console.debug('[S&S] Error formatting long date string:', error);
+      Logger.debug('Error formatting long date string:', error);
       const weekdayName = this.getWeekdayName('long');
       const monthName = this.getMonthName('long');
       const dayOrdinal = this.getDayString('long');
@@ -250,7 +251,7 @@ export class CalendarDate implements ICalendarDate {
         format: 'long',
       });
     } catch (error) {
-      console.debug('[S&S] Error formatting date string:', error);
+      Logger.debug('Error formatting date string:', error);
       const weekdayName = this.getWeekdayName('long');
       const monthName = this.getMonthName('long');
       const dayOrdinal = this.getDayString('long');
@@ -290,7 +291,7 @@ export class CalendarDate implements ICalendarDate {
     try {
       const weekday = this.calendar.weekdays?.[this.weekday];
       if (!weekday) {
-        console.debug(`[S&S] Invalid weekday index: ${this.weekday}`);
+        Logger.debug(`Invalid weekday index: ${this.weekday}`);
         return 'Unknown';
       }
 
@@ -300,7 +301,7 @@ export class CalendarDate implements ICalendarDate {
 
       return weekday.name || 'Unknown';
     } catch (error) {
-      console.debug('[S&S] Error getting weekday name:', error);
+      Logger.debug('Error getting weekday name:', error);
       return 'Unknown';
     }
   }
@@ -312,7 +313,7 @@ export class CalendarDate implements ICalendarDate {
     try {
       const month = this.calendar.months?.[this.month - 1];
       if (!month) {
-        console.debug(`[S&S] Invalid month index: ${this.month}`);
+        Logger.debug(`Invalid month index: ${this.month}`);
         return 'Unknown';
       }
 
@@ -322,7 +323,7 @@ export class CalendarDate implements ICalendarDate {
 
       return month.name || 'Unknown';
     } catch (error) {
-      console.debug('[S&S] Error getting month name:', error);
+      Logger.debug('Error getting month name:', error);
       return 'Unknown';
     }
   }
@@ -333,7 +334,7 @@ export class CalendarDate implements ICalendarDate {
   private getDayString(format: 'short' | 'long' | 'numeric'): string {
     try {
       if (typeof this.day !== 'number' || this.day < 1) {
-        console.debug(`[S&S] Invalid day value: ${this.day}`);
+        Logger.debug(`Invalid day value: ${this.day}`);
         return '1';
       }
 
@@ -348,7 +349,7 @@ export class CalendarDate implements ICalendarDate {
 
       return this.day.toString();
     } catch (error) {
-      console.debug('[S&S] Error formatting day string:', error);
+      Logger.debug('Error formatting day string:', error);
       return '1';
     }
   }
@@ -359,14 +360,14 @@ export class CalendarDate implements ICalendarDate {
   private getYearString(): string {
     try {
       if (typeof this.year !== 'number') {
-        console.debug(`[S&S] Invalid year value: ${this.year}`);
+        Logger.debug(`Invalid year value: ${this.year}`);
         return '1';
       }
 
       const { prefix = '', suffix = '' } = this.calendar.year || {};
       return `${prefix}${this.year}${suffix}`.trim();
     } catch (error) {
-      console.debug('[S&S] Error formatting year string:', error);
+      Logger.debug('Error formatting year string:', error);
       return this.year?.toString() || '1';
     }
   }
@@ -382,7 +383,7 @@ export class CalendarDate implements ICalendarDate {
 
       // Validate time components
       if (typeof hour !== 'number' || typeof minute !== 'number' || typeof second !== 'number') {
-        console.debug(`[S&S] Invalid time components:`, { hour, minute, second });
+        Logger.debug('Invalid time components:', { hour, minute, second });
         return '00:00:00';
       }
 
@@ -393,7 +394,7 @@ export class CalendarDate implements ICalendarDate {
 
       return `${hourStr}:${minuteStr}:${secondStr}`;
     } catch (error) {
-      console.debug('[S&S] Error formatting time string:', error);
+      Logger.debug('Error formatting time string:', error);
       return '00:00:00';
     }
   }
@@ -404,12 +405,12 @@ export class CalendarDate implements ICalendarDate {
   private addOrdinalSuffix(num: number): string {
     try {
       if (typeof num !== 'number' || num < 1) {
-        console.debug(`[S&S] Invalid number for ordinal suffix: ${num}`);
+        Logger.debug(`Invalid number for ordinal suffix: ${num}`);
         return '1st';
       }
       return CalendarTimeUtils.addOrdinalSuffix(num);
     } catch (error) {
-      console.debug('[S&S] Error adding ordinal suffix:', error);
+      Logger.debug('Error adding ordinal suffix:', error);
       return `${num || 1}th`;
     }
   }
@@ -437,7 +438,7 @@ export class CalendarDate implements ICalendarDate {
   compareTo(other: CalendarDateData): number {
     try {
       if (!other || typeof other !== 'object') {
-        console.debug('[S&S] Invalid date data provided for comparison:', other);
+        Logger.debug('Invalid date data provided for comparison:', other);
         return 0;
       }
 
@@ -454,7 +455,7 @@ export class CalendarDate implements ICalendarDate {
 
       return 0;
     } catch (error) {
-      console.debug('[S&S] Error comparing dates:', error);
+      Logger.debug('Error comparing dates:', error);
       return 0;
     }
   }

--- a/packages/core/src/core/calendar-validator.ts
+++ b/packages/core/src/core/calendar-validator.ts
@@ -3,6 +3,7 @@
  */
 
 // Schema files will be loaded dynamically from the module
+import { Logger } from './logger';
 
 export interface ValidationResult {
   isValid: boolean;
@@ -27,7 +28,7 @@ async function getAjvValidators() {
       addFormats(ajvInstance);
     } catch {
       // ajv-formats is optional
-      console.warn('ajv-formats not available, some validations may be limited');
+      Logger.warn('ajv-formats not available, some validations may be limited');
     }
 
     // Load schemas based on environment
@@ -148,7 +149,7 @@ export class CalendarValidator {
       return result;
     } catch (error) {
       // Fallback to non-schema validation if AJV fails
-      console.warn('Schema validation failed, falling back to legacy validation:', error);
+      Logger.warn('Schema validation failed, falling back to legacy validation:', error);
       return this.validateLegacy(calendar);
     }
   }

--- a/packages/core/src/core/date-formatter.ts
+++ b/packages/core/src/core/date-formatter.ts
@@ -5,6 +5,7 @@
 import type { CalendarDate as ICalendarDate } from './calendar-date';
 import { CalendarDate } from './calendar-date';
 import type { SeasonsStarsCalendar } from '../types/calendar';
+import { Logger } from './logger';
 
 export class DateFormatter {
   private calendar: SeasonsStarsCalendar;
@@ -139,12 +140,12 @@ export class DateFormatter {
       if (formatName && this.calendar.id) {
         // Calendar-specific format error
         const calendarName = this.calendar.name || this.calendar.id;
-        console.warn(
-          `[S&S] Calendar "${calendarName}" has syntax errors in "${formatName}" format: ${error.message}`
+        Logger.warn(
+          `Calendar "${calendarName}" has syntax errors in "${formatName}" format: ${error.message}`
         );
       } else {
         // Generic template error
-        console.warn(`[S&S] Date format template has syntax errors: ${error.message}`);
+        Logger.warn(`Date format template has syntax errors: ${error.message}`);
       }
     }
   }
@@ -182,7 +183,7 @@ export class DateFormatter {
   ): string {
     // Type safety check at entry point
     if (typeof template !== 'string') {
-      console.debug('[S&S] Invalid template type passed to format(), falling back to basic format');
+      Logger.debug('Invalid template type passed to format(), falling back to basic format');
       return this.getBasicFormat(date);
     }
 
@@ -198,7 +199,7 @@ export class DateFormatter {
 
       // Validate template output - detect malformed templates that produce empty/invalid output
       if (this.isInvalidTemplateOutput(result, template)) {
-        console.debug('[S&S] Template produced invalid output, falling back to basic format:', {
+        Logger.debug('Template produced invalid output, falling back to basic format:', {
           template,
           result,
         });
@@ -207,7 +208,7 @@ export class DateFormatter {
 
       return result;
     } catch (error) {
-      console.debug('[S&S] Date format template compilation failed:', error);
+      Logger.debug('Date format template compilation failed:', error);
 
       // Notify user about the error
       this.notifyTemplateError(
@@ -237,7 +238,7 @@ export class DateFormatter {
 
     // Prevent circular references - check before adding to visited
     if (visited.has(formatName)) {
-      console.debug(`[S&S] Circular reference detected in format '${formatName}'`);
+      Logger.debug(`Circular reference detected in format '${formatName}'`);
       return this.getBasicFormat(date);
     }
 
@@ -347,8 +348,8 @@ export class DateFormatter {
       (this.calendar.months.length > 0 && date.month > this.calendar.months.length)
     ) {
       // Only log as debug for legitimate edge cases, no user-visible warnings
-      console.debug(
-        `[S&S] Month value ${date.month} outside calendar range (1-${this.calendar.months.length}), using start of year fallback`
+      Logger.debug(
+        `Month value ${date.month} outside calendar range (1-${this.calendar.months.length}), using start of year fallback`
       );
       // Return 1 to indicate start of year, which is more meaningful than raw day value
       // This prevents confusing calculations in stardate helpers and other features

--- a/packages/core/src/core/errors-and-echoes-integration.ts
+++ b/packages/core/src/core/errors-and-echoes-integration.ts
@@ -1,0 +1,157 @@
+import { Logger } from './logger';
+import { CalendarWidget } from '../ui/calendar-widget';
+import { CalendarMiniWidget } from '../ui/calendar-mini-widget';
+import { CalendarGridWidget } from '../ui/calendar-grid-widget';
+import type { ErrorsAndEchoesAPI } from '../types/external-integrations';
+import type { CalendarManager } from './calendar-manager';
+
+/**
+ * Register Errors & Echoes integration using a calendar manager getter.
+ * Keeping this separate reduces clutter in module.ts
+ */
+export function registerErrorsAndEchoesIntegration(
+  getCalendarManager: () => CalendarManager | undefined
+): void {
+  Hooks.once('errorsAndEchoesReady', (errorsAndEchoesAPI: ErrorsAndEchoesAPI) => {
+    try {
+      Logger.debug('Registering with Errors and Echoes via hook');
+
+      errorsAndEchoesAPI.register({
+        moduleId: 'seasons-and-stars',
+
+        // Context provider - adds useful debugging information
+        contextProvider: () => {
+          const context: Record<string, unknown> = {};
+          const calendarManager = getCalendarManager();
+
+          // Add current calendar information - safe property access
+          if (calendarManager) {
+            const currentDate = calendarManager.getCurrentDate();
+            const activeCalendar = calendarManager.getActiveCalendar();
+
+            context.currentDate = currentDate
+              ? `${currentDate.year}-${currentDate.month}-${currentDate.day}`
+              : 'unknown';
+            context.activeCalendarId = activeCalendar?.id || 'unknown';
+            context.calendarEngineAvailable = !!calendarManager.getActiveEngine();
+          }
+
+          // Add widget state - simple property checks don't need try-catch
+          const activeWidgets: string[] = [];
+          if (CalendarWidget.getInstance?.()?.rendered) activeWidgets.push('main');
+          if (CalendarMiniWidget.getInstance?.()?.rendered) activeWidgets.push('mini');
+          if (CalendarGridWidget.getInstance?.()?.rendered) activeWidgets.push('grid');
+          context.activeWidgets = activeWidgets;
+
+          // Add system information - basic property access
+          context.gameSystem = game.system?.id || 'unknown';
+          context.foundryVersion = game.version || 'unknown';
+          context.smallTimeDetected = !!document.querySelector('#smalltime-app');
+
+          return context;
+        },
+
+        // Error filter - focus on errors relevant to S&S functionality
+        errorFilter: (error: Error) => {
+          const stack = error.stack || '';
+          const message = error.message || '';
+
+          // Always report errors that mention our module explicitly
+          if (
+            stack.includes('seasons-and-stars') ||
+            message.includes('seasons-and-stars') ||
+            message.includes('S&S') ||
+            stack.includes('CalendarManager') ||
+            stack.includes('CalendarWidget') ||
+            stack.includes('CalendarEngine') ||
+            stack.includes('NotesManager')
+          ) {
+            return false; // Don't filter (report this error)
+          }
+
+          // Report time/calendar related errors that might affect us
+          if (
+            message.includes('worldTime') ||
+            message.includes('game.time') ||
+            message.includes('calendar') ||
+            message.includes('dateToWorldTime') ||
+            message.includes('worldTimeToDate') ||
+            (message.includes('time') && stack.includes('foundry'))
+          ) {
+            return false; // Don't filter (time system errors affect us)
+          }
+
+          // Report widget positioning and UI errors
+          if (
+            message.includes('widget') ||
+            message.includes('SmallTime') ||
+            message.includes('player list') ||
+            (message.includes('position') && stack.includes('ui')) ||
+            message.includes('ApplicationV2')
+          ) {
+            return false; // Don't filter (UI errors might affect our widgets)
+          }
+
+          // Report integration-related errors
+          if (
+            message.includes('Simple Calendar') ||
+            message.includes('simple-calendar') ||
+            message.includes('compatibility') ||
+            message.includes('bridge') ||
+            stack.includes('integration')
+          ) {
+            return false; // Don't filter (integration errors affect us)
+          }
+
+          // Report foundry core time system errors
+          if (
+            stack.includes('foundry.js') &&
+            (message.includes('time') || message.includes('world') || message.includes('scene'))
+          ) {
+            return false; // Don't filter (core time system issues)
+          }
+
+          // Filter out errors from unrelated modules (unless they mention calendar/time)
+          const unrelatedModules = [
+            'dice-so-nice',
+            'lib-wrapper',
+            'socketlib',
+            'combat-utility-belt',
+            'enhanced-terrain-layer',
+            'token-action-hud',
+            'foundryvtt-forien-quest-log',
+          ];
+
+          for (const module of unrelatedModules) {
+            if (
+              stack.includes(module) &&
+              !message.includes('calendar') &&
+              !message.includes('time') &&
+              !stack.includes('seasons-and-stars')
+            ) {
+              return true; // Filter out (unrelated module error)
+            }
+          }
+
+          // Default: filter out most other errors unless they seem time/calendar related
+          if (
+            message.includes('calendar') ||
+            message.includes('time') ||
+            message.includes('date')
+          ) {
+            return false; // Don't filter (might be related)
+          }
+
+          return true; // Filter out everything else
+        },
+      });
+
+      Logger.debug('Successfully registered with Errors and Echoes via hook');
+    } catch (error) {
+      Logger.error(
+        'Failed to register with Errors and Echoes via hook',
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  });
+}

--- a/packages/core/src/core/notes-cleanup.ts
+++ b/packages/core/src/core/notes-cleanup.ts
@@ -1,0 +1,75 @@
+import { Logger } from './logger';
+import { CalendarWidget } from '../ui/calendar-widget';
+import { CalendarMiniWidget } from '../ui/calendar-mini-widget';
+import { CalendarGridWidget } from '../ui/calendar-grid-widget';
+import type { NotesManager } from './notes-manager';
+
+type HooksSystem = Pick<typeof Hooks, 'on' | 'callAll'> & Partial<Pick<typeof Hooks, 'off'>>;
+
+/**
+ * Register hooks to clean up notes when their journal entries are deleted externally.
+ */
+export function registerNotesCleanupHooks(
+  notesManager: NotesManager,
+  hooks: HooksSystem = Hooks
+): () => void {
+  const handleJournalDeletion = async (
+    journal: JournalEntry,
+    _options: Record<string, unknown>,
+    _userId: string
+  ) => {
+    Logger.debug('Journal deletion detected', {
+      journalId: journal.id,
+      journalName: journal.name,
+      isCalendarNote: !!journal.flags?.['seasons-and-stars']?.calendarNote,
+    });
+
+    try {
+      // Check if this was a calendar note
+      const flags = journal.flags?.['seasons-and-stars'];
+      if (flags?.calendarNote) {
+        Logger.info('Calendar note deleted externally, cleaning up storage', {
+          noteId: journal.id,
+          noteName: journal.name,
+        });
+
+        // Remove from our storage system
+        if (notesManager?.storage) {
+          await notesManager.storage.removeNote(journal.id);
+          Logger.debug('Note removed from storage');
+        }
+
+        // Emit our own deletion hook for UI updates
+        hooks.callAll('seasons-stars:noteDeleted', journal.id);
+
+        // Refresh calendar widgets to remove the note from display
+        const calendarWidget = CalendarWidget.getInstance?.();
+        if (calendarWidget?.rendered) {
+          calendarWidget.render();
+        }
+        const miniWidget = CalendarMiniWidget.getInstance?.();
+        if (miniWidget?.rendered) {
+          miniWidget.render();
+        }
+        const gridWidget = CalendarGridWidget.getInstance?.();
+        if (gridWidget?.rendered) {
+          gridWidget.render();
+        }
+      }
+    } catch (error) {
+      Logger.error(
+        'Failed to clean up deleted calendar note',
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  };
+
+  hooks.on('deleteJournalEntry', handleJournalDeletion);
+  Logger.debug('Notes cleanup hooks registered');
+
+  return () => {
+    if (hooks.off) {
+      hooks.off('deleteJournalEntry', handleJournalDeletion);
+    }
+  };
+}

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -31,11 +31,9 @@ import { TimeAdvancementService } from './core/time-advancement-service';
 import type { MemoryMageAPI } from './types/external-integrations';
 import { registerSettingsPreviewHooks } from './core/settings-preview';
 import type { SeasonsStarsAPI } from './types/foundry-extensions';
-import type {
-  ErrorsAndEchoesAPI,
-  ExtendedNotesManager,
-  ExtendedCalendarManager,
-} from './types/external-integrations';
+import { registerErrorsAndEchoesIntegration } from './core/errors-and-echoes-integration';
+import { registerNotesCleanupHooks } from './core/notes-cleanup';
+import type { ExtendedNotesManager, ExtendedCalendarManager } from './types/external-integrations';
 import type {
   CalendarDate as ICalendarDate,
   DateFormatOptions,
@@ -79,145 +77,8 @@ export function setSeasonsWarningState(warned: boolean): void {
 // Register scene controls at top level (critical timing requirement)
 SeasonsStarsSceneControls.registerControls();
 
-// Register Errors and Echoes hook at top level (RECOMMENDED - eliminates timing issues)
-Hooks.once('errorsAndEchoesReady', (errorsAndEchoesAPI: ErrorsAndEchoesAPI) => {
-  // E&E is guaranteed to be ready when this hook is called
-  try {
-    Logger.debug('Registering with Errors and Echoes via hook');
-
-    errorsAndEchoesAPI.register({
-      moduleId: 'seasons-and-stars',
-
-      // Context provider - adds useful debugging information
-      contextProvider: () => {
-        const context: Record<string, unknown> = {};
-
-        // Add current calendar information - safe property access
-        if (calendarManager) {
-          const currentDate = calendarManager.getCurrentDate();
-          const activeCalendar = calendarManager.getActiveCalendar();
-
-          context.currentDate = currentDate
-            ? `${currentDate.year}-${currentDate.month}-${currentDate.day}`
-            : 'unknown';
-          context.activeCalendarId = activeCalendar?.id || 'unknown';
-          context.calendarEngineAvailable = !!calendarManager.getActiveEngine();
-        }
-
-        // Add widget state - simple property checks don't need try-catch
-        const activeWidgets: string[] = [];
-        if (CalendarWidget.getInstance?.()?.rendered) activeWidgets.push('main');
-        if (CalendarMiniWidget.getInstance?.()?.rendered) activeWidgets.push('mini');
-        if (CalendarGridWidget.getInstance?.()?.rendered) activeWidgets.push('grid');
-        context.activeWidgets = activeWidgets;
-
-        // Add system information - basic property access
-        context.gameSystem = game.system?.id || 'unknown';
-        context.foundryVersion = game.version || 'unknown';
-        context.smallTimeDetected = !!document.querySelector('#smalltime-app');
-
-        return context;
-      },
-
-      // Error filter - focus on errors relevant to S&S functionality
-      errorFilter: (error: Error) => {
-        const stack = error.stack || '';
-        const message = error.message || '';
-
-        // Always report errors that mention our module explicitly
-        if (
-          stack.includes('seasons-and-stars') ||
-          message.includes('seasons-and-stars') ||
-          message.includes('S&S') ||
-          stack.includes('CalendarManager') ||
-          stack.includes('CalendarWidget') ||
-          stack.includes('CalendarEngine') ||
-          stack.includes('NotesManager')
-        ) {
-          return false; // Don't filter (report this error)
-        }
-
-        // Report time/calendar related errors that might affect us
-        if (
-          message.includes('worldTime') ||
-          message.includes('game.time') ||
-          message.includes('calendar') ||
-          message.includes('dateToWorldTime') ||
-          message.includes('worldTimeToDate') ||
-          (message.includes('time') && stack.includes('foundry'))
-        ) {
-          return false; // Don't filter (time system errors affect us)
-        }
-
-        // Report widget positioning and UI errors
-        if (
-          message.includes('widget') ||
-          message.includes('SmallTime') ||
-          message.includes('player list') ||
-          (message.includes('position') && stack.includes('ui')) ||
-          message.includes('ApplicationV2')
-        ) {
-          return false; // Don't filter (UI errors might affect our widgets)
-        }
-
-        // Report integration-related errors
-        if (
-          message.includes('Simple Calendar') ||
-          message.includes('simple-calendar') ||
-          message.includes('compatibility') ||
-          message.includes('bridge') ||
-          stack.includes('integration')
-        ) {
-          return false; // Don't filter (integration errors affect us)
-        }
-
-        // Report foundry core time system errors
-        if (
-          stack.includes('foundry.js') &&
-          (message.includes('time') || message.includes('world') || message.includes('scene'))
-        ) {
-          return false; // Don't filter (core time system issues)
-        }
-
-        // Filter out errors from unrelated modules (unless they mention calendar/time)
-        const unrelatedModules = [
-          'dice-so-nice',
-          'lib-wrapper',
-          'socketlib',
-          'combat-utility-belt',
-          'enhanced-terrain-layer',
-          'token-action-hud',
-          'foundryvtt-forien-quest-log',
-        ];
-
-        for (const module of unrelatedModules) {
-          if (
-            stack.includes(module) &&
-            !message.includes('calendar') &&
-            !message.includes('time') &&
-            !stack.includes('seasons-and-stars')
-          ) {
-            return true; // Filter out (unrelated module error)
-          }
-        }
-
-        // Default: filter out most other errors unless they seem time/calendar related
-        if (message.includes('calendar') || message.includes('time') || message.includes('date')) {
-          return false; // Don't filter (might be related)
-        }
-
-        return true; // Filter out everything else
-      },
-    });
-
-    Logger.debug('Successfully registered with Errors and Echoes via hook');
-  } catch (error) {
-    Logger.error(
-      'Failed to register with Errors and Echoes via hook',
-      error instanceof Error ? error : new Error(String(error))
-    );
-  }
-});
+// Register Errors and Echoes integration separately
+registerErrorsAndEchoesIntegration(() => calendarManager);
 
 /**
  * Module initialization
@@ -288,7 +149,7 @@ Hooks.once('ready', async () => {
   await notesManager.initialize();
 
   // Register notes cleanup hooks for external journal deletion
-  registerNotesCleanupHooks();
+  registerNotesCleanupHooks(notesManager);
 
   // Register with Memory Mage if available
   registerMemoryMageIntegration();
@@ -1710,64 +1571,6 @@ function getActiveWidgetCount(): number {
   if (CalendarGridWidget.getInstance?.()?.rendered) count++;
 
   return count;
-}
-
-/**
- * Register hooks to clean up notes when journals are deleted externally
- */
-function registerNotesCleanupHooks(): void {
-  // Hook into journal deletion to clean up our notes storage
-  Hooks.on(
-    'deleteJournalEntry',
-    async (journal: JournalEntry, _options: Record<string, unknown>, _userId: string) => {
-      Logger.debug('Journal deletion detected', {
-        journalId: journal.id,
-        journalName: journal.name,
-        isCalendarNote: !!journal.flags?.['seasons-and-stars']?.calendarNote,
-      });
-
-      try {
-        // Check if this was a calendar note
-        const flags = journal.flags?.['seasons-and-stars'];
-        if (flags?.calendarNote) {
-          Logger.info('Calendar note deleted externally, cleaning up storage', {
-            noteId: journal.id,
-            noteName: journal.name,
-          });
-
-          // Remove from our storage system
-          if (notesManager?.storage) {
-            await notesManager.storage.removeNote(journal.id);
-            Logger.debug('Note removed from storage');
-          }
-
-          // Emit our own deletion hook for UI updates
-          Hooks.callAll('seasons-stars:noteDeleted', journal.id);
-
-          // Refresh calendar widgets to remove the note from display
-          const calendarWidget = CalendarWidget.getInstance?.();
-          if (calendarWidget?.rendered) {
-            calendarWidget.render();
-          }
-          const miniWidget = CalendarMiniWidget.getInstance?.();
-          if (miniWidget?.rendered) {
-            miniWidget.render();
-          }
-          const gridWidget = CalendarGridWidget.getInstance?.();
-          if (gridWidget?.rendered) {
-            gridWidget.render();
-          }
-        }
-      } catch (error) {
-        Logger.error(
-          'Failed to clean up deleted calendar note',
-          error instanceof Error ? error : new Error(String(error))
-        );
-      }
-    }
-  );
-
-  Logger.debug('Notes cleanup hooks registered');
 }
 
 // Export functions for testing

--- a/packages/core/src/ui/calendar-grid-widget.ts
+++ b/packages/core/src/ui/calendar-grid-widget.ts
@@ -376,7 +376,7 @@ export class CalendarGridWidget extends foundry.applications.api.HandlebarsAppli
         }
       } catch (error) {
         // Silently handle moon calculation errors to avoid breaking calendar display
-        console.debug('Error calculating moon phases for date:', dayDate, error);
+        Logger.debug('Error calculating moon phases for date:', { dayDate, error });
       }
 
       currentWeek.push({

--- a/packages/core/test/note-deletion-cleanup.test.ts
+++ b/packages/core/test/note-deletion-cleanup.test.ts
@@ -3,10 +3,11 @@
  * Tests that the notes cleanup hook properly removes deleted journals from storage
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CalendarWidget } from '../src/ui/calendar-widget';
 import { CalendarMiniWidget } from '../src/ui/calendar-mini-widget';
 import { CalendarGridWidget } from '../src/ui/calendar-grid-widget';
+import { registerNotesCleanupHooks } from '../src/core/notes-cleanup';
 
 // Mock the logger module with simple vi.fn() mocks
 vi.mock('../src/core/logger', () => ({
@@ -25,7 +26,13 @@ vi.mock('../src/core/logger', () => ({
 describe('Note Deletion Cleanup (Issue #22)', () => {
   let mockNotesManager: any;
   let mockJournal: any;
-  let hookCallback: Function;
+  let hookCallback: (journal: any, options: any, userId: string) => Promise<void> | void;
+  let mockHooks: {
+    on: ReturnType<typeof vi.fn>;
+    callAll: ReturnType<typeof vi.fn>;
+    off: ReturnType<typeof vi.fn>;
+  };
+  let disposeHook: (() => void) | undefined;
 
   beforeEach(() => {
     // Reset mocks
@@ -61,57 +68,36 @@ describe('Note Deletion Cleanup (Issue #22)', () => {
     vi.spyOn(CalendarMiniWidget, 'getInstance').mockReturnValue(mockWidgetInstance);
     vi.spyOn(CalendarGridWidget, 'getInstance').mockReturnValue(mockWidgetInstance);
 
-    // Mock Hooks.on to capture the callback
-    global.Hooks = {
-      on: vi.fn((hookName: string, callback: Function) => {
+    hookCallback = async () => {};
+
+    // Mock hook system to capture callbacks
+    mockHooks = {
+      on: vi.fn((hookName: string, callback: typeof hookCallback) => {
         if (hookName === 'deleteJournalEntry') {
           hookCallback = callback;
         }
+        return 0;
       }),
       callAll: vi.fn(),
-    } as any;
+      off: vi.fn(),
+    };
 
-    // Make notes manager available globally (simulating module initialization)
-    (global as any).notesManager = mockNotesManager;
+    disposeHook = undefined;
+  });
+
+  afterEach(() => {
+    if (disposeHook) {
+      disposeHook();
+      disposeHook = undefined;
+    }
+    vi.restoreAllMocks();
   });
 
   it('should clean up calendar notes when journals are deleted externally', async () => {
-    // Simulate the hook registration from module.ts
-    const registerNotesCleanupHooks = () => {
-      Hooks.on('deleteJournalEntry', async (journal: any, options: any, userId: string) => {
-        try {
-          const flags = journal.flags?.['seasons-and-stars'];
-          if (flags?.calendarNote) {
-            if ((global as any).notesManager?.storage) {
-              await (global as any).notesManager.storage.removeNote(journal.id);
-            }
-            Hooks.callAll('seasons-stars:noteDeleted', journal.id);
-
-            // Refresh widgets (simplified for test)
-            const calendarWidget = CalendarWidget.getInstance?.();
-            if (calendarWidget?.rendered) {
-              calendarWidget.render();
-            }
-            const miniWidget = CalendarMiniWidget.getInstance?.();
-            if (miniWidget?.rendered) {
-              miniWidget.render();
-            }
-            const gridWidget = CalendarGridWidget.getInstance?.();
-            if (gridWidget?.rendered) {
-              gridWidget.render();
-            }
-          }
-        } catch (error) {
-          // Error handling would use Logger here
-        }
-      });
-    };
-
-    // Register the hooks
-    registerNotesCleanupHooks();
+    disposeHook = registerNotesCleanupHooks(mockNotesManager, mockHooks as any);
 
     // Verify hook was registered
-    expect(Hooks.on).toHaveBeenCalledWith('deleteJournalEntry', expect.any(Function));
+    expect(mockHooks.on).toHaveBeenCalledWith('deleteJournalEntry', expect.any(Function));
 
     // Simulate journal deletion
     await hookCallback(mockJournal, {}, 'test-user-id');
@@ -120,72 +106,47 @@ describe('Note Deletion Cleanup (Issue #22)', () => {
     expect(mockNotesManager.storage.removeNote).toHaveBeenCalledWith('test-journal-123');
 
     // Verify hook was emitted for UI updates
-    expect(Hooks.callAll).toHaveBeenCalledWith('seasons-stars:noteDeleted', 'test-journal-123');
+    expect(mockHooks.callAll).toHaveBeenCalledWith('seasons-stars:noteDeleted', 'test-journal-123');
 
     // Verify widgets were refreshed
     expect(CalendarWidget.getInstance).toHaveBeenCalled();
     expect(CalendarMiniWidget.getInstance).toHaveBeenCalled();
     expect(CalendarGridWidget.getInstance).toHaveBeenCalled();
+
+    // Dispose removes the hook when supported
+    disposeHook();
+    disposeHook = undefined;
+    expect(mockHooks.off).toHaveBeenCalledWith('deleteJournalEntry', expect.any(Function));
   });
 
   it('should ignore non-calendar journals during deletion', async () => {
-    // Create a regular journal without calendar flags
     const regularJournal = {
       id: 'regular-journal-456',
       name: 'Regular Journal',
-      flags: {}, // No seasons-and-stars flags
+      flags: {},
     };
 
-    // Register hooks
-    Hooks.on('deleteJournalEntry', async (journal: any) => {
-      const flags = journal.flags?.['seasons-and-stars'];
-      if (flags?.calendarNote) {
-        if ((global as any).notesManager?.storage) {
-          await (global as any).notesManager.storage.removeNote(journal.id);
-        }
-        Hooks.callAll('seasons-stars:noteDeleted', journal.id);
-      }
-    });
+    disposeHook = registerNotesCleanupHooks(mockNotesManager, mockHooks as any);
 
-    // Simulate deletion of regular journal
     await hookCallback(regularJournal, {}, 'test-user-id');
 
-    // Verify storage cleanup was NOT called for regular journals
     expect(mockNotesManager.storage.removeNote).not.toHaveBeenCalled();
-
-    // Verify deletion hook was NOT emitted for regular journals
-    expect(Hooks.callAll).not.toHaveBeenCalledWith('seasons-stars:noteDeleted', expect.any(String));
+    expect(mockHooks.callAll).not.toHaveBeenCalledWith(
+      'seasons-stars:noteDeleted',
+      expect.any(String)
+    );
   });
 
   it('should handle errors gracefully during cleanup', async () => {
-    // Make storage.removeNote throw an error
     mockNotesManager.storage.removeNote.mockRejectedValue(new Error('Storage error'));
 
-    // Register hooks with error handling
-    Hooks.on('deleteJournalEntry', async (journal: any) => {
-      try {
-        const flags = journal.flags?.['seasons-and-stars'];
-        if (flags?.calendarNote) {
-          if ((global as any).notesManager?.storage) {
-            await (global as any).notesManager.storage.removeNote(journal.id);
-          }
-          Hooks.callAll('seasons-stars:noteDeleted', journal.id);
-        }
-      } catch (error) {
-        // Error would be logged but not thrown
-        // Test that the error doesn't propagate
-      }
-    });
+    disposeHook = registerNotesCleanupHooks(mockNotesManager, mockHooks as any);
 
-    // Simulate journal deletion that causes error
     await expect(hookCallback(mockJournal, {}, 'test-user-id')).resolves.not.toThrow();
-
-    // Verify storage cleanup was attempted
     expect(mockNotesManager.storage.removeNote).toHaveBeenCalledWith('test-journal-123');
   });
 
   it('should handle widgets that are not rendered', async () => {
-    // Mock widgets as not rendered
     const mockUnrenderedWidget = {
       rendered: false,
       render: vi.fn(),
@@ -195,37 +156,11 @@ describe('Note Deletion Cleanup (Issue #22)', () => {
     vi.spyOn(CalendarMiniWidget, 'getInstance').mockReturnValue(mockUnrenderedWidget);
     vi.spyOn(CalendarGridWidget, 'getInstance').mockReturnValue(mockUnrenderedWidget);
 
-    // Register hooks
-    Hooks.on('deleteJournalEntry', async (journal: any) => {
-      const flags = journal.flags?.['seasons-and-stars'];
-      if (flags?.calendarNote) {
-        if ((global as any).notesManager?.storage) {
-          await (global as any).notesManager.storage.removeNote(journal.id);
-        }
+    disposeHook = registerNotesCleanupHooks(mockNotesManager, mockHooks as any);
 
-        // Try to refresh widgets
-        const calendarWidget = CalendarWidget.getInstance?.();
-        if (calendarWidget?.rendered) {
-          calendarWidget.render();
-        }
-        const miniWidget = CalendarMiniWidget.getInstance?.();
-        if (miniWidget?.rendered) {
-          miniWidget.render();
-        }
-        const gridWidget = CalendarGridWidget.getInstance?.();
-        if (gridWidget?.rendered) {
-          gridWidget.render();
-        }
-      }
-    });
-
-    // Simulate journal deletion
     await hookCallback(mockJournal, {}, 'test-user-id');
 
-    // Verify storage cleanup still happened
     expect(mockNotesManager.storage.removeNote).toHaveBeenCalledWith('test-journal-123');
-
-    // Verify widgets were not rendered (since they're not active)
     expect(mockUnrenderedWidget.render).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- allow notes cleanup hook registration to inject a Hooks-like API and return a disposer for cleanup
- update the note deletion cleanup test suite to exercise the exported helper with controllable hooks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfad755e94832799244e66520277d3