### PR TITLE
fix: correct Golarion imperial year offset

### DIFF
--- a/packages/core/test/calendar-variants.test.ts
+++ b/packages/core/test/calendar-variants.test.ts
@@ -124,7 +124,7 @@ describe('Calendar Variants System', () => {
           'imperial-calendar': {
             name: 'Imperial Calendar',
             description: 'Chelish Imperial dating system',
-            config: { yearOffset: 5200 },
+            config: { yearOffset: 7200 },
             overrides: {
               year: { suffix: ' IC' },
               months: { Abadius: { name: 'First Imperial' } },
@@ -161,7 +161,7 @@ describe('Calendar Variants System', () => {
           'imperial-calendar': {
             name: 'Imperial Calendar',
             description: 'Chelish Imperial dating system',
-            config: { yearOffset: 5200 },
+            config: { yearOffset: 7200 },
             overrides: {
               year: { suffix: ' IC' },
               months: {

--- a/packages/core/test/calendar-year-offset-variants.test.ts
+++ b/packages/core/test/calendar-year-offset-variants.test.ts
@@ -351,7 +351,7 @@ describe('Calendar Year Offset Variants Bug Fix', () => {
             name: 'Imperial Calendar',
             description: 'Chelish Imperial dating system',
             config: {
-              yearOffset: 5200, // +2500 years from base
+              yearOffset: 7200, // +4500 years from base
             },
             overrides: {
               year: {
@@ -393,9 +393,9 @@ describe('Calendar Year Offset Variants Bug Fix', () => {
       expect(absalomVariant?.year.currentYear).toBe(4725);
       expect(absalomVariant?.year.suffix).toBe(' AR');
 
-      // Imperial Calendar: +2500 years from base
-      expect(imperialVariant?.year.epoch).toBe(5200);
-      expect(imperialVariant?.year.currentYear).toBe(7225); // 4725 + 2500
+      // Imperial Calendar: +4500 years from base
+      expect(imperialVariant?.year.epoch).toBe(7200);
+      expect(imperialVariant?.year.currentYear).toBe(9225); // 4725 + 4500
       expect(imperialVariant?.year.suffix).toBe(' IC');
 
       // Earth Historical: -2795 years from base
@@ -406,7 +406,7 @@ describe('Calendar Year Offset Variants Bug Fix', () => {
 
     it('should demonstrate the user-reported bug with Imperial Calendar', () => {
       // This test specifically demonstrates the bug reported in issue #141
-      // When switching from AR to IC, the year should change by +2500
+      // When switching from AR to IC, the year should change by +4500
 
       // Arrange: Simplified calendar to focus on the bug
       const golarionCalendar: SeasonsStarsCalendar = {
@@ -437,7 +437,7 @@ describe('Calendar Year Offset Variants Bug Fix', () => {
           'imperial-calendar': {
             name: 'Imperial Calendar',
             description: 'Chelish Imperial dating system',
-            config: { yearOffset: 5200 }, // This should add 2500 years
+            config: { yearOffset: 7200 }, // This should add 4500 years
             overrides: { year: { suffix: ' IC' } },
           },
         },
@@ -452,13 +452,13 @@ describe('Calendar Year Offset Variants Bug Fix', () => {
       // Assert: This demonstrates the exact bug - years should be different but aren't
       expect(arVariant?.year.currentYear).toBe(4725); // AR year
 
-      // FAILING TEST: IC should show 7225 (4725 + 2500) but currently shows 4725
-      expect(icVariant?.year.currentYear).toBe(7225); // Should be AR year + 2500
+      // FAILING TEST: IC should show 9225 (4725 + 4500) but currently shows 4725
+      expect(icVariant?.year.currentYear).toBe(9225); // Should be AR year + 4500
 
-      // The difference should be exactly 2500 years
+      // The difference should be exactly 4500 years
       const yearDifference =
         (icVariant?.year.currentYear || 0) - (arVariant?.year.currentYear || 0);
-      expect(yearDifference).toBe(2500);
+      expect(yearDifference).toBe(4500);
     });
   });
 });

--- a/packages/pf2e-pack/calendars/golarion-pf2e.json
+++ b/packages/pf2e-pack/calendars/golarion-pf2e.json
@@ -230,7 +230,7 @@
       "name": "Imperial Calendar",
       "description": "Tian Xia Imperial dating system used in the Dragon Empires",
       "config": {
-        "yearOffset": 5200
+        "yearOffset": 7200
       },
       "overrides": {
         "year": {


### PR DESCRIPTION
## Summary
- update the Imperial Calendar variant for Golarion to use a 7200 year offset
- refresh calendar variant tests to assert the new 7200 epoch and 9225 current year values
- align calendar year offset regression coverage with the revised 4500-year delta

## Testing
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02fa326608327828c90c8720cf40c