### PR TITLE
chore: fix lint errors and add tests for getMiniDimensions method

### DIFF
--- a/packages/core/src/ui/calendar-mini-widget.ts
+++ b/packages/core/src/ui/calendar-mini-widget.ts
@@ -1213,13 +1213,14 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
         const height = rect.height > 0 ? rect.height : WIDGET_POSITIONING.MINI_WIDGET_HEIGHT;
         return { width, height };
       }
-    } catch (_) {}
+    } catch {
+      // Silently handle any errors during element measurement
+    }
     return {
       width: WIDGET_POSITIONING.MINI_WIDGET_WIDTH,
-      height: WIDGET_POSITIONING.MINI_WIDGET_HEIGHT
+      height: WIDGET_POSITIONING.MINI_WIDGET_HEIGHT,
     };
   }
-
 
   /**
    * Check if a position would place the widget outside viewport boundaries

--- a/packages/core/test/ui/calendar-mini-widget.test.ts
+++ b/packages/core/test/ui/calendar-mini-widget.test.ts
@@ -738,5 +738,105 @@ describe('CalendarMiniWidget', () => {
         expect(corrected.left).toBeLessThan(1500);
       });
     });
+
+    describe('getMiniDimensions()', () => {
+      it('should return actual dimensions when element exists and has size', () => {
+        const mockElement = {
+          querySelector: vi.fn().mockReturnValue({
+            getBoundingClientRect: vi.fn().mockReturnValue({
+              width: 250,
+              height: 150,
+            }),
+          }),
+        };
+        widget.element = mockElement as any;
+
+        const dimensions = (widget as any).getMiniDimensions();
+
+        expect(dimensions).toEqual({ width: 250, height: 150 });
+        expect(mockElement.querySelector).toHaveBeenCalledWith('.calendar-mini-content');
+      });
+
+      it('should use fallback dimensions when element has zero width', () => {
+        const mockElement = {
+          querySelector: vi.fn().mockReturnValue({
+            getBoundingClientRect: vi.fn().mockReturnValue({
+              width: 0,
+              height: 150,
+            }),
+          }),
+        };
+        widget.element = mockElement as any;
+
+        const dimensions = (widget as any).getMiniDimensions();
+
+        expect(dimensions.width).toBe(200); // WIDGET_POSITIONING.MINI_WIDGET_WIDTH
+        expect(dimensions.height).toBe(150);
+      });
+
+      it('should use fallback dimensions when element has zero height', () => {
+        const mockElement = {
+          querySelector: vi.fn().mockReturnValue({
+            getBoundingClientRect: vi.fn().mockReturnValue({
+              width: 250,
+              height: 0,
+            }),
+          }),
+        };
+        widget.element = mockElement as any;
+
+        const dimensions = (widget as any).getMiniDimensions();
+
+        expect(dimensions.width).toBe(250);
+        expect(dimensions.height).toBe(80); // WIDGET_POSITIONING.MINI_WIDGET_HEIGHT
+      });
+
+      it('should return fallback dimensions when element is null', () => {
+        const mockElement = {
+          querySelector: vi.fn().mockReturnValue(null),
+        };
+        widget.element = mockElement as any;
+
+        const dimensions = (widget as any).getMiniDimensions();
+
+        expect(dimensions).toEqual({ width: 200, height: 80 });
+      });
+
+      it('should return fallback dimensions when widget.element is null', () => {
+        widget.element = null;
+
+        const dimensions = (widget as any).getMiniDimensions();
+
+        expect(dimensions).toEqual({ width: 200, height: 80 });
+      });
+
+      it('should handle querySelector errors gracefully', () => {
+        const mockElement = {
+          querySelector: vi.fn().mockImplementation(() => {
+            throw new Error('DOM error');
+          }),
+        };
+        widget.element = mockElement as any;
+
+        const dimensions = (widget as any).getMiniDimensions();
+
+        expect(dimensions).toEqual({ width: 200, height: 80 });
+      });
+
+      it('should handle getBoundingClientRect errors gracefully', () => {
+        const mockElement = {
+          querySelector: vi.fn().mockReturnValue({
+            getBoundingClientRect: vi.fn().mockImplementation(() => {
+              throw new Error('Rect error');
+            }),
+          }),
+        };
+        widget.element = mockElement as any;
+
+        const dimensions = (widget as any).getMiniDimensions();
+
+        expect(dimensions).toEqual({ width: 200, height: 80 });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Fixed lint errors in calendar-mini-widget.ts (unused parameter and empty catch block)
- Added comprehensive test coverage for the new `getMiniDimensions()` method
- Ensured all tests pass and code quality standards are met

## Changes Made
- **Lint Fixes**: Removed unused parameter `_` and empty catch block, added proper error handling comment
- **Test Coverage**: Added 7 new test cases covering:
  - Normal dimension measurement when element exists
  - Fallback behavior for zero width/height elements
  - Null element handling
  - Error handling for DOM measurement failures

## Test Plan
- [x] All existing tests continue to pass (1418 tests)
- [x] New tests for `getMiniDimensions()` method pass
- [x] Lint checks pass with 0 errors
- [x] TypeScript compilation succeeds
- [x] Code formatting is consistent

🤖 Generated with [Claude Code](https://claude.ai/code)