### PR TITLE
feat: redesign calendar selection dialog

### DIFF
--- a/packages/core/languages/de.json
+++ b/packages/core/languages/de.json
@@ -31,7 +31,26 @@
         "sample_dates": "Beispieldaten",
         "structure": "Kalenderstruktur",
         "no_calendars": "Keine Kalender verfügbar",
-        "no_calendars_hint": "Es wurden keine Kalenderdateien gefunden. Bitte stelle sicher, dass die Kalenderdaten ordnungsgemäß installiert sind."
+        "no_calendars_hint": "Es wurden keine Kalenderdateien gefunden. Bitte stelle sicher, dass die Kalenderdaten ordnungsgemäß installiert sind.",
+        "search_placeholder": "Kalender durchsuchen...",
+        "filter_source_label": "Quellmodul",
+        "filter_source_all": "Alle Quellen",
+        "filter_tags_label": "Nach Tags filtern",
+        "filter_tags_placeholder": "z. B. Fantasy, Offiziell, Lunar...",
+        "results_count": "{count} Kalender gefunden",
+        "clear_filters": "Filter zurücksetzen",
+        "add_custom_calendar": "Eigenen Kalender hinzufügen",
+        "description_header": "Beschreibung",
+        "tags_header": "Tags",
+        "preview_header": "Vorschau",
+        "preview_sample_label": "Beispieldatum",
+        "preview_mini_label": "Mini-Widget",
+        "no_selection_message": "Wählen Sie einen Kalender aus der Liste, um Details anzuzeigen.",
+        "unknown_source": "Unbekannte Quelle",
+        "unknown_author": "Unbekannter Autor",
+        "custom_group_label": "Eigene Dateien",
+        "custom_group_description": "Kalender, die aus eigenen JSON-Dateien geladen wurden.",
+        "tag_custom": "Eigen"
       },
       "calendar_preview": {
         "title": "Kalendervorschau: {calendar}"

--- a/packages/core/languages/de.json
+++ b/packages/core/languages/de.json
@@ -48,6 +48,7 @@
         "no_selection_message": "Wählen Sie einen Kalender aus der Liste, um Details anzuzeigen.",
         "unknown_source": "Unbekannte Quelle",
         "unknown_author": "Unbekannter Autor",
+        "variant_label": "Variante: {variant}",
         "custom_group_label": "Eigene Dateien",
         "custom_group_description": "Kalender, die aus eigenen JSON-Dateien geladen wurden.",
         "tag_custom": "Eigen"

--- a/packages/core/languages/en.json
+++ b/packages/core/languages/en.json
@@ -43,7 +43,26 @@
         "file_loaded": "Custom calendar file is loaded and ready to use",
         "file_path": "File Path",
         "status": "Status",
-        "click_to_select": "Click to select a calendar file"
+        "click_to_select": "Click to select a calendar file",
+        "search_placeholder": "Search calendars...",
+        "filter_source_label": "Source Module",
+        "filter_source_all": "All Sources",
+        "filter_tags_label": "Filter by Tags",
+        "filter_tags_placeholder": "e.g. Fantasy, Official, Lunar...",
+        "results_count": "{count} calendars found",
+        "clear_filters": "Clear Filters",
+        "add_custom_calendar": "Add Custom Calendar",
+        "description_header": "Description",
+        "tags_header": "Tags",
+        "preview_header": "Preview",
+        "preview_sample_label": "Sample Date",
+        "preview_mini_label": "Mini Widget",
+        "no_selection_message": "Select a calendar from the list to view details.",
+        "unknown_source": "Unknown Source",
+        "unknown_author": "Unknown Author",
+        "custom_group_label": "Custom Files",
+        "custom_group_description": "Calendars loaded from custom JSON files.",
+        "tag_custom": "Custom"
       },
       "calendar_preview": {
         "title": "Calendar Preview: {calendar}"

--- a/packages/core/languages/en.json
+++ b/packages/core/languages/en.json
@@ -60,6 +60,7 @@
         "no_selection_message": "Select a calendar from the list to view details.",
         "unknown_source": "Unknown Source",
         "unknown_author": "Unknown Author",
+        "variant_label": "Variant: {variant}",
         "custom_group_label": "Custom Files",
         "custom_group_description": "Calendars loaded from custom JSON files.",
         "tag_custom": "Custom"

--- a/packages/core/languages/pl.json
+++ b/packages/core/languages/pl.json
@@ -43,7 +43,26 @@
         "file_loaded": "Plik kalendarza niestandardowego został załadowany i jest gotowy do użycia",
         "file_path": "Ścieżka pliku",
         "status": "Status",
-        "click_to_select": "Kliknij, aby wybrać plik kalendarza"
+        "click_to_select": "Kliknij, aby wybrać plik kalendarza",
+        "search_placeholder": "Szukaj kalendarzy...",
+        "filter_source_label": "Moduł źródłowy",
+        "filter_source_all": "Wszystkie źródła",
+        "filter_tags_label": "Filtruj według tagów",
+        "filter_tags_placeholder": "np. Fantasy, Oficjalny, Księżycowy...",
+        "results_count": "Znaleziono {count} kalendarzy",
+        "clear_filters": "Wyczyść filtry",
+        "add_custom_calendar": "Dodaj kalendarz niestandardowy",
+        "description_header": "Opis",
+        "tags_header": "Tagi",
+        "preview_header": "Podgląd",
+        "preview_sample_label": "Przykładowa data",
+        "preview_mini_label": "Mini widżet",
+        "no_selection_message": "Wybierz kalendarz z listy, aby zobaczyć szczegóły.",
+        "unknown_source": "Nieznane źródło",
+        "unknown_author": "Nieznany autor",
+        "custom_group_label": "Pliki niestandardowe",
+        "custom_group_description": "Kalendarze wczytane z własnych plików JSON.",
+        "tag_custom": "Niestandardowy"
       },
       "calendar_preview": {
         "title": "Podgląd kalendarza: {calendar}"

--- a/packages/core/languages/pl.json
+++ b/packages/core/languages/pl.json
@@ -60,6 +60,7 @@
         "no_selection_message": "Wybierz kalendarz z listy, aby zobaczyć szczegóły.",
         "unknown_source": "Nieznane źródło",
         "unknown_author": "Nieznany autor",
+        "variant_label": "Wariant: {variant}",
         "custom_group_label": "Pliki niestandardowe",
         "custom_group_description": "Kalendarze wczytane z własnych plików JSON.",
         "tag_custom": "Niestandardowy"

--- a/packages/core/src/styles/calendar-selection-dialog.scss
+++ b/packages/core/src/styles/calendar-selection-dialog.scss
@@ -66,6 +66,10 @@
           }
         }
       }
+
+      .button:first-child {
+        margin-right: auto;
+      }
     }
   }
 
@@ -206,6 +210,40 @@
             i {
               font-size: 0.75rem;
               color: var(--color-text-light-7);
+            }
+          }
+
+          .multi-select-options {
+            display: none;
+            position: absolute;
+            top: calc(100% + 0.35rem);
+            left: 0;
+            right: 0;
+            background: rgba(12, 12, 20, 0.95);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 10px;
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+            padding: 0.5rem;
+            pointer-events: none;
+            z-index: 10;
+
+            .multi-select-option {
+              display: flex;
+              align-items: center;
+              gap: 0.5rem;
+              padding: 0.4rem 0.5rem;
+              border-radius: 6px;
+              font-size: 0.8rem;
+              color: var(--color-text-light-6);
+
+              input {
+                pointer-events: none;
+                accent-color: var(--color-warm-2, #f6b26b);
+              }
+
+              span {
+                flex: 1;
+              }
             }
           }
         }
@@ -502,6 +540,7 @@
     .calendar-preview {
       display: grid;
       gap: 0.75rem;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 
       .sample-preview,
       .mini-preview {

--- a/packages/core/src/styles/calendar-selection-dialog.scss
+++ b/packages/core/src/styles/calendar-selection-dialog.scss
@@ -1,698 +1,578 @@
 /**
- * Calendar Selection Dialog - Native Foundry Integration
+ * Calendar Selection Dialog - Master Detail Layout
  */
 
 .seasons-stars.calendar-selection-dialog {
-  // Use native Foundry CSS Grid system with scrolling
-  .calendar-selection-grid {
-    display: grid;
-    grid-template-columns: 1fr; // Single column for wider cards
+  .calendar-selection-master-detail {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
     gap: 1.25rem;
-    min-height: 300px;
-    max-height: 520px;
+    padding: 1.5rem;
+    box-sizing: border-box;
+    background: radial-gradient(circle at top left, rgba(60, 60, 84, 0.35), transparent 55%),
+      linear-gradient(180deg, rgba(20, 20, 32, 0.96), rgba(10, 10, 18, 0.98));
+    border-radius: 18px;
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.55);
+
+    .dialog-buttons {
+      margin-top: auto;
+      display: flex;
+      justify-content: flex-end;
+      gap: 0.75rem;
+      padding-top: 1rem;
+      border-top: 1px solid rgba(255, 255, 255, 0.05);
+
+      .button {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.12);
+        border-radius: 999px;
+        padding: 0.45rem 1.2rem;
+        color: var(--color-text-light-primary);
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+
+        &:hover {
+          background: rgba(255, 255, 255, 0.15);
+        }
+
+        &:disabled {
+          opacity: 0.45;
+          cursor: not-allowed;
+
+          &:hover {
+            background: rgba(255, 255, 255, 0.08);
+          }
+        }
+
+        &.primary {
+          background: linear-gradient(135deg, rgba(243, 144, 79, 0.85), rgba(248, 190, 120, 0.9));
+          border-color: rgba(248, 190, 120, 0.9);
+          color: rgba(24, 16, 8, 0.92);
+
+          &:hover {
+            background: linear-gradient(135deg, rgba(248, 190, 120, 0.95), rgba(243, 144, 79, 0.95));
+          }
+
+          &:disabled {
+            background: linear-gradient(135deg, rgba(243, 144, 79, 0.55), rgba(248, 190, 120, 0.6));
+            border-color: rgba(248, 190, 120, 0.4);
+            color: rgba(24, 16, 8, 0.65);
+          }
+        }
+      }
+    }
+  }
+
+  .calendar-selection-header {
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
+    padding: 1.25rem 1.5rem;
+    gap: 0.75rem;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+
+    .header-title {
+      align-items: center;
+      gap: 1rem;
+    }
+
+    .header-icon {
+      width: 52px;
+      height: 52px;
+      border-radius: 14px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: linear-gradient(135deg, rgba(243, 144, 79, 0.9), rgba(255, 206, 150, 0.95));
+      color: rgba(28, 18, 12, 0.95);
+      font-size: 1.6rem;
+      box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
+      flex-shrink: 0;
+    }
+
+    .header-text {
+      gap: 0.4rem;
+
+      h1 {
+        margin: 0;
+        font-size: 1.45rem;
+        color: var(--color-text-light-primary);
+        letter-spacing: 0.6px;
+      }
+
+      .header-description {
+        margin: 0;
+        font-size: 0.9rem;
+        color: var(--color-text-light-5);
+        line-height: 1.5;
+      }
+    }
+  }
+
+  .calendar-browser {
+    flex: 1;
+    display: flex;
+    gap: 1.25rem;
+    height: 100%;
+    min-height: 0;
+  }
+
+  .calendar-list-panel {
+    width: 340px;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-height: 0;
+    background: linear-gradient(180deg, rgba(36, 36, 48, 0.85), rgba(22, 22, 32, 0.95));
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    border-radius: 12px;
+    padding: 1rem;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02);
+  }
+
+  .calendar-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    background: rgba(0, 0, 0, 0.25);
+    border-radius: 10px;
+    padding: 0.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+
+    input {
+      background: rgba(18, 18, 28, 0.8);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 8px;
+      color: var(--color-text-light-primary);
+      padding: 0.5rem 0.75rem;
+      font-size: 0.85rem;
+
+      &::placeholder {
+        color: var(--color-text-light-7);
+      }
+
+      &:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+    }
+
+    label {
+      font-size: 0.75rem;
+      letter-spacing: 0.5px;
+      text-transform: uppercase;
+      color: var(--color-text-light-6);
+      margin-bottom: 0.35rem;
+      display: block;
+    }
+
+    .filter-section {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+
+      .filter-group {
+        flex: 1;
+        min-width: 140px;
+        display: flex;
+        flex-direction: column;
+
+        .multi-select-dropdown {
+          position: relative;
+
+          .multi-select-trigger {
+            width: 100%;
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            background: rgba(18, 18, 28, 0.8);
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-radius: 8px;
+            padding: 0.5rem 0.75rem;
+            font-size: 0.85rem;
+            color: var(--color-text-light-4);
+
+            &:disabled {
+              opacity: 0.6;
+              cursor: not-allowed;
+            }
+
+            i {
+              font-size: 0.75rem;
+              color: var(--color-text-light-7);
+            }
+          }
+        }
+      }
+    }
+
+    .filter-status {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.8rem;
+      color: var(--color-text-light-6);
+
+      .clear-filters {
+        display: flex;
+        align-items: center;
+        gap: 0.35rem;
+        background: transparent;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: 999px;
+        padding: 0.25rem 0.6rem;
+        color: var(--color-text-light-6);
+        font-size: 0.7rem;
+
+        &.hidden {
+          display: none;
+        }
+
+        &:disabled {
+          opacity: 0.5;
+          cursor: not-allowed;
+        }
+      }
+    }
+  }
+
+  .calendar-list {
+    flex: 1;
     overflow-y: auto;
-    overflow-x: hidden;
-    padding: 0.5rem 0.75rem 0.5rem 0.5rem; // Better padding with scrollbar space
-    
-    // Ensure smooth scrolling
-    scroll-behavior: smooth;
-    
-    // Enhanced scrollbar styling for Foundry
+    padding-right: 0.35rem;
+
+    &::-webkit-scrollbar {
+      width: 6px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 4px;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: rgba(255, 255, 255, 0.2);
+      border-radius: 4px;
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.35);
+      }
+    }
+  }
+
+  .calendar-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+
+    .group-header {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      color: var(--color-text-light-4);
+      font-weight: 600;
+      letter-spacing: 0.4px;
+
+      .source-icon {
+        color: var(--color-accent-3, #f3904f);
+      }
+
+      .calendar-count {
+        font-size: 0.75rem;
+        color: var(--color-text-light-7);
+      }
+    }
+
+    .calendar-items {
+      display: flex;
+      flex-direction: column;
+      gap: 0.4rem;
+    }
+  }
+
+  .calendar-item {
+    background: rgba(18, 18, 28, 0.85);
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    padding: 0.65rem 0.75rem;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    cursor: pointer;
+
+    &:hover {
+      border-color: rgba(255, 255, 255, 0.2);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+      transform: translateX(2px);
+    }
+
+    &.selected {
+      border-color: var(--color-warm-2, #f6b26b);
+      box-shadow: 0 0 0 1px rgba(246, 178, 107, 0.45);
+      background: linear-gradient(90deg, rgba(246, 178, 107, 0.15), rgba(18, 18, 28, 0.85));
+    }
+
+    &.current {
+      border-color: var(--color-warm-3, #ffcb80);
+    }
+
+    &.hierarchy-level-1 {
+      margin-left: 1.25rem;
+      border-left: 3px solid rgba(255, 255, 255, 0.12);
+    }
+
+    .calendar-item-content {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+
+      .calendar-icon {
+        width: 32px;
+        height: 32px;
+        border-radius: 8px;
+        background: rgba(255, 255, 255, 0.08);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--color-text-light-primary);
+        flex-shrink: 0;
+      }
+
+      .calendar-info {
+        flex: 1;
+        min-width: 0;
+
+        .calendar-name {
+          font-size: 0.95rem;
+          font-weight: 600;
+          color: var(--color-text-light-primary);
+          margin-bottom: 0.2rem;
+        }
+
+        .variant-info,
+        .calendar-setting {
+          font-size: 0.7rem;
+          color: var(--color-text-light-6);
+          letter-spacing: 0.4px;
+        }
+
+        .calendar-tags {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.3rem;
+          margin-top: 0.4rem;
+
+          .tag {
+            background: rgba(255, 255, 255, 0.08);
+            border-radius: 999px;
+            padding: 0.15rem 0.5rem;
+            font-size: 0.65rem;
+            letter-spacing: 0.4px;
+            color: var(--color-text-light-5);
+            text-transform: uppercase;
+          }
+        }
+      }
+
+      .current-indicator {
+        color: var(--color-warm-1, #ffd966);
+        font-size: 1rem;
+      }
+    }
+  }
+
+  .custom-calendar-actions {
+    margin-top: auto;
+
+    .add-custom-calendar {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.5rem;
+      padding: 0.65rem 0.75rem;
+      border-radius: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      background: rgba(255, 255, 255, 0.05);
+      color: var(--color-text-light-primary);
+      font-weight: 600;
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.12);
+      }
+    }
+  }
+
+  .calendar-details-panel {
+    flex: 1;
+    background: linear-gradient(180deg, rgba(28, 28, 40, 0.95), rgba(18, 18, 28, 0.98));
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    border-radius: 12px;
+    padding: 1.25rem;
+    display: flex;
+    min-height: 0;
+  }
+
+  .calendar-details {
+    flex: 1;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-height: 0;
+
     &::-webkit-scrollbar {
       width: 8px;
     }
-    
+
     &::-webkit-scrollbar-track {
-      background: var(--color-bg-alt);
-      border-radius: 4px;
-      margin: 4px 0;
+      background: rgba(255, 255, 255, 0.05);
     }
-    
+
     &::-webkit-scrollbar-thumb {
-      background: linear-gradient(180deg, var(--color-border-light-secondary), var(--color-border-light-tertiary));
+      background: rgba(255, 255, 255, 0.2);
       border-radius: 4px;
-      border: 1px solid var(--color-bg-alt);
-      
-      &:hover {
-        background: linear-gradient(180deg, var(--color-border-light-primary), var(--color-border-light-secondary));
-      }
-      
-      &:active {
-        background: var(--color-warm-3);
-      }
-    }
-    
-    // Add subtle fade effect at top/bottom when scrolling
-    &::before, &::after {
-      content: '';
-      position: sticky;
-      display: block;
-      height: 8px;
-      margin: 0 -0.5rem;
-      z-index: 1;
-      pointer-events: none;
-    }
-    
-    &::before {
-      top: 0;
-      background: linear-gradient(to bottom, var(--color-bg-option), transparent);
-    }
-    
-    &::after {
-      bottom: 0;
-      background: linear-gradient(to top, var(--color-bg-option), transparent);
     }
   }
 
-  // Calendar cards using native ui-control pattern
-  .calendar-card {
-    // Extend Foundry's ui-control base styling
-    padding: 1.25rem;
-    border-radius: 6px;
-    min-height: 220px;
-    cursor: var(--cursor-pointer, pointer);
-    width: 100%; // Ensure cards use full available width
-    position: relative;
-    overflow: hidden;
-    
-    // Use Foundry's interactive colors with enhanced gradients
-    border: 1px solid var(--color-border-light-tertiary);
-    background: linear-gradient(145deg, var(--color-bg-option), var(--color-bg-alt));
-    transition: all 0.3s ease;
-    
-    // Add subtle inner shadow for depth
-    box-shadow: 
-      inset 0 1px 0 rgba(255, 255, 255, 0.1),
-      0 2px 4px rgba(0, 0, 0, 0.1);
+  .details-header {
+    gap: 0.4rem;
 
-    // Enhanced Foundry hover effect
-    &:hover {
-      text-shadow: 0 0 8px var(--color-shadow-primary);
-      border-color: var(--color-warm-2);
-      background: linear-gradient(145deg, var(--color-bg-primary), var(--color-bg-option));
-      box-shadow: 
-        inset 0 1px 0 rgba(255, 255, 255, 0.15),
-        0 4px 12px rgba(0, 0, 0, 0.15),
-        0 0 8px var(--color-shadow-primary);
-      transform: translateY(-2px);
-    }
-
-    // Enhanced active state
-    &.active {
-      background: linear-gradient(145deg, var(--color-bg-primary), var(--color-warm-5));
-      border-color: var(--color-warm-2);
-      box-shadow: 
-        inset 0 1px 0 rgba(255, 255, 255, 0.2),
-        0 0 12px var(--color-warm-1);
-      
-      &::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 3px;
-        background: linear-gradient(90deg, var(--color-warm-1), var(--color-warm-2), var(--color-warm-1));
-        z-index: 1;
-      }
-    }
-
-    // Enhanced picked/selected state
-    &.picked {
-      outline: 2px solid var(--color-warm-1);
-      outline-offset: -1px;
-      box-shadow: 
-        inset 0 1px 0 rgba(255, 255, 255, 0.2),
-        0 0 16px var(--color-warm-1),
-        inset 0 0 20px rgba(255, 200, 100, 0.1);
-      background: linear-gradient(145deg, var(--color-bg-primary), var(--color-warm-5));
-      border-color: var(--color-warm-1);
-      
-      &::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        right: 0;
-        width: 0;
-        height: 0;
-        border-top: 24px solid var(--color-warm-1);
-        border-left: 24px solid transparent;
-        z-index: 2;
-      }
-      
-      // Add checkmark in corner
-      &::before {
-        content: '✓';
-        position: absolute;
-        top: 4px;
-        right: 6px;
-        color: white;
-        font-size: 12px;
-        font-weight: bold;
-        z-index: 3;
-      }
-    }
-    
-    // Variant calendar cards have a subtle visual distinction
-    &.variant {
-      border-left: 3px solid var(--color-cool-2);
-      margin-left: 1rem;
-      
-      // No connecting line - just indentation and border
-      
-      &:hover {
-        border-left-color: var(--color-cool-1);
-      }
-      
-      &.picked {
-        border-left-color: var(--color-warm-1);
-      }
-      
-      .calendar-name .variant-indicator i {
-        transform: rotate(45deg);
-      }
-    }
-
-    // Hierarchical indentation for variants
-    &.hierarchy-level-1 {
-      margin-left: 1.5rem;
-      border-left: 2px solid var(--color-cool-3);
-      
-      // No connecting line - just indentation and border
-      
-      .calendar-name {
-        font-size: 1rem; // Slightly smaller for hierarchy
-        
-        .variant-indicator {
-          color: var(--color-cool-2);
-          opacity: 0.9;
-        }
-      }
-      
-      &:hover {
-        border-left-color: var(--color-cool-2);
-      }
-      
-      &.picked {
-        border-left-color: var(--color-warm-2);
-      }
-    }
-
-    .card-header {
-      margin-bottom: 0.5rem;
-      gap: 0.5rem;
-
-      .calendar-title-row {
-        align-items: flex-start;
-        gap: 0.5rem;
-
-        .calendar-title-info {
-          flex: 1;
-          min-width: 0;
-
-          .calendar-name {
-            margin: 0 0 0.25rem 0;
-            font-size: 1.1rem;
-            font-weight: 600;
-            color: var(--color-text-light-primary);
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            
-            .variant-indicator {
-              color: var(--color-cool-1);
-              font-size: 0.9rem;
-              opacity: 0.8;
-              
-              i {
-                transform: rotate(0deg);
-                transition: transform 0.2s ease;
-              }
-            }
-          }
-
-          .calendar-setting {
-            font-size: 0.8rem;
-            color: var(--color-text-light-7);
-            font-style: italic;
-          }
-          
-          .variant-info {
-            font-size: 0.75rem;
-            color: var(--color-cool-2);
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            background: var(--color-bg-secondary);
-            padding: 0.125rem 0.375rem;
-            border-radius: 3px;
-            border: 1px solid var(--color-cool-5);
-            margin-top: 0.25rem;
-            display: inline-block;
-          }
-        }
-
-        .calendar-badges {
-          flex-shrink: 0;
-          align-items: center;
-          gap: 0.375rem;
-
-          .current-badge {
-            color: var(--color-warm-1);
-            font-size: 1.2rem;
-            filter: drop-shadow(0 0 4px var(--color-warm-1));
-            animation: current-star-glow 3s ease-in-out infinite alternate;
-            
-            i {
-              transform-origin: center;
-            }
-          }
-
-          .module-badge {
-            padding: 0.25rem 0.5rem;
-            border-radius: 12px;
-            font-size: 0.7rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-            pointer-events: none; // Make it non-interactive
-            
-            // Default (dark theme) styling
-            background: linear-gradient(135deg, var(--color-cool-2), var(--color-cool-1));
-            color: var(--color-text-light-primary);
-            border: 1px solid var(--color-cool-3);
-            
-            i {
-              margin-right: 0.25rem;
-              font-size: 0.8rem;
-            }
-            
-            // Add "MODULE" text after icon for clarity
-            &::after {
-              content: 'MODULE';
-            }
-          }
-
-          .external-badge {
-            padding: 0.25rem 0.5rem;
-            border-radius: 12px;
-            font-size: 0.7rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-            pointer-events: none; // Make it non-interactive
-            
-            // Default (dark theme) styling
-            background: linear-gradient(135deg, var(--color-border-light-secondary), var(--color-border-light-tertiary));
-            color: var(--color-text-light-primary);
-            border: 1px solid var(--color-border-light-primary);
-            
-            i {
-              margin-right: 0.25rem;
-              font-size: 0.8rem;
-            }
-            
-            // Add "EXTERNAL" text after icon for clarity
-            &::after {
-              content: 'EXTERNAL';
-            }
-          }
-        }
-      }
-      
-      .source-info {
-        align-items: center;
-        gap: 0.625rem;
-        width: 100%; // Take full width now that it's on its own row
-        background: rgba(0, 0, 0, 0.1);
-        padding: 0.5rem 0.75rem;
-        border-radius: 4px;
-        margin-top: 0.5rem;
-        border: 1px solid rgba(255, 255, 255, 0.05);
-        
-        .source-icon {
-          font-size: 0.9rem;
-          color: var(--color-text-light-5);
-          flex-shrink: 0;
-          width: 1.1rem;
-          text-align: center;
-        }
-        
-        .source-label {
-          font-size: 0.85rem;
-          color: var(--color-text-light-5);
-          font-weight: 600;
-          word-break: break-word;
-          line-height: 1.3;
-          flex: 1;
-          text-transform: uppercase;
-          letter-spacing: 0.3px;
-        }
-      }
-    }
-
-    .card-content {
-      flex: 1;
-      gap: 0.75rem;
-
-      .calendar-description {
-        font-size: 0.9rem;
-        line-height: 1.4;
-        margin: 0;
-        color: var(--color-text-light-6);
-      }
-
-      .preview-section {
-        margin-top: auto;
-        
-        .sample-preview, 
-        .mini-preview {
-          background: linear-gradient(145deg, var(--color-bg-secondary), var(--color-bg-alt));
-          border: 1px solid var(--color-border-light-tertiary);
-          border-radius: 5px;
-          padding: 0.75rem;
-          margin-bottom: 0.75rem;
-          box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-          transition: all 0.2s ease;
-          
-          &:hover {
-            background: linear-gradient(145deg, var(--color-bg-alt), var(--color-bg-secondary));
-            border-color: var(--color-border-light-secondary);
-            box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.15);
-          }
-
-          label {
-            font-size: 0.7rem;
-            font-weight: 700;
-            color: var(--color-text-light-6);
-            text-transform: uppercase;
-            letter-spacing: 0.8px;
-            margin-bottom: 0.375rem;
-            display: flex;
-            align-items: center;
-            gap: 0.25rem;
-            
-            &::before {
-              content: '◆';
-              font-size: 0.6rem;
-              color: var(--color-cool-2);
-            }
-          }
-
-          .sample-date,
-          .mini-format {
-            font-family: var(--font-mono);
-            font-size: 0.9rem;
-            color: var(--color-text-light-primary);
-            font-weight: 600;
-            line-height: 1.3;
-            background: rgba(0, 0, 0, 0.1);
-            padding: 0.25rem 0.5rem;
-            border-radius: 3px;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-          }
-        }
-        
-        .mini-preview {
-          background: linear-gradient(145deg, var(--color-warm-5), var(--color-warm-4));
-          border-color: var(--color-warm-3);
-          
-          &:hover {
-            background: linear-gradient(145deg, var(--color-warm-4), var(--color-warm-3));
-            border-color: var(--color-warm-2);
-          }
-          
-          label {
-            color: var(--color-warm-1);
-            
-            &::before {
-              color: var(--color-warm-2);
-              content: '★';
-            }
-          }
-          
-          .mini-format {
-            color: var(--color-warm-1);
-            font-weight: 700;
-            background: rgba(255, 200, 100, 0.1);
-            border-color: var(--color-warm-3);
-          }
-        }
-      }
-    }
-
-    .card-actions {
-      margin-top: 0.75rem;
-      align-items: center;
-      gap: 0.5rem;
-
-      // Use native Foundry button styling
-      button.button {
-        flex: 1;
-        padding: 0.375rem 0.75rem;
-        font-size: 0.8rem;
-        
-        i {
-          margin-right: 0.25rem;
-        }
-      }
-
-      .selected-indicator {
-        color: var(--color-warm-1);
-        font-size: 1.1rem;
-        animation: foundry-pulse 2s infinite;
-      }
-    }
-  }
-
-  // No calendars state
-  .no-calendars {
-    padding: 3rem;
-    text-align: center;
-    color: var(--color-text-light-7);
-    min-height: 200px;
-    justify-content: center;
-
-    .no-calendars-icon {
-      font-size: 3rem;
-      margin-bottom: 1rem;
-      opacity: 0.5;
-      color: var(--color-text-light-7);
-    }
-
-    .no-calendars-message {
-      h4 {
-        margin: 0 0 0.5rem 0;
-        color: var(--color-text-light-primary);
-        font-weight: 600;
-      }
-
-      p {
-        margin: 0;
-        font-size: 0.9rem;
-        max-width: 300px;
-      }
-    }
-  }
-}
-
-// Calendar Preview Dialog Styles
-.seasons-stars.calendar-preview-dialog {
-  .calendar-preview {
-    padding: 1rem;
-    max-width: none;
-    
-    .preview-header {
-      margin-bottom: 1.5rem;
-      padding-bottom: 1rem;
-      border-bottom: 1px solid var(--color-border-light-secondary);
-      
-      h3 {
-        margin: 0 0 0.5rem 0;
-        font-size: 1.4rem;
-        font-weight: 600;
-        color: var(--color-text-light-primary);
-        line-height: 1.2;
-      }
-      
-      .preview-setting {
-        font-size: 0.9rem;
-        color: var(--color-text-light-secondary);
-        font-style: italic;
-        margin-top: 0.25rem;
-      }
-    }
-    
-    .preview-description {
-      margin-bottom: 1.5rem;
-      padding: 1rem;
-      background: var(--color-bg-secondary);
-      border: 1px solid var(--color-border-light-secondary);
-      border-radius: 4px;
-      font-size: 0.95rem;
-      line-height: 1.5;
+    .calendar-title {
+      font-size: 1.4rem;
+      margin: 0;
       color: var(--color-text-light-primary);
     }
-    
-    .preview-samples {
-      margin-bottom: 1.5rem;
-      
-      h4 {
-        margin: 0 0 0.75rem 0;
-        font-size: 1.1rem;
-        font-weight: 600;
-        color: var(--color-text-light-primary);
-        display: flex;
-        align-items: center;
-        
-        &::before {
-          content: "📅";
-          margin-right: 0.5rem;
-          font-size: 1rem;
-        }
-      }
-      
-      .sample-date {
-        background: var(--color-bg-option);
-        border: 1px solid var(--color-border-light-secondary);
-        border-radius: 3px;
-        padding: 0.5rem 0.75rem;
-        margin-bottom: 0.5rem;
-        font-family: var(--font-mono);
-        font-size: 0.9rem;
-        color: var(--color-text-light-primary);
-        font-weight: 500;
-        
-        &:last-child {
-          margin-bottom: 0;
-        }
+
+    .calendar-author,
+    .calendar-source {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+      font-size: 0.85rem;
+      color: var(--color-text-light-5);
+
+      .source-icon {
+        color: var(--color-accent-3, #f3904f);
       }
     }
-    
-    .preview-structure {
-      h4 {
-        margin: 0 0 0.75rem 0;
-        font-size: 1.1rem;
-        font-weight: 600;
-        color: var(--color-text-light-primary);
-        display: flex;
-        align-items: center;
-        
-        &::before {
-          content: "📊";
-          margin-right: 0.5rem;
-          font-size: 1rem;
-        }
+  }
+
+  .details-section {
+    background: rgba(0, 0, 0, 0.25);
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    border-radius: 10px;
+    padding: 0.85rem 1rem;
+
+    h4 {
+      margin: 0 0 0.5rem;
+      font-size: 0.95rem;
+      letter-spacing: 0.6px;
+      text-transform: uppercase;
+      color: var(--color-text-light-5);
+    }
+
+    .calendar-description {
+      margin: 0;
+      font-size: 0.9rem;
+      line-height: 1.5;
+      color: var(--color-text-light-4);
+    }
+
+    .calendar-tags-display {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.4rem;
+
+      .tag {
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 999px;
+        padding: 0.25rem 0.6rem;
+        font-size: 0.7rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
       }
-      
-      .structure-info {
-        background: var(--color-bg-secondary);
-        border: 1px solid var(--color-border-light-secondary);
-        border-radius: 4px;
-        padding: 1rem;
-        
-        div {
-          margin-bottom: 0.5rem;
-          font-size: 0.9rem;
+    }
+
+    .calendar-preview {
+      display: grid;
+      gap: 0.75rem;
+
+      .sample-preview,
+      .mini-preview {
+        background: rgba(0, 0, 0, 0.35);
+        border: 1px solid rgba(255, 255, 255, 0.05);
+        border-radius: 8px;
+        padding: 0.75rem;
+
+        label {
+          display: block;
+          font-size: 0.7rem;
+          letter-spacing: 0.4px;
+          text-transform: uppercase;
+          color: var(--color-text-light-6);
+          margin-bottom: 0.35rem;
+        }
+
+        .sample-date,
+        .mini-format {
+          font-size: 1rem;
           color: var(--color-text-light-primary);
-          
-          &:last-child {
-            margin-bottom: 0;
-          }
-          
-          strong {
-            color: var(--color-text-light-primary);
-            font-weight: 600;
-            margin-right: 0.25rem;
-          }
         }
       }
     }
-  }
-}
 
-// Dialog footer buttons
-.dialog-buttons {
-  padding: 1rem;
-  gap: 0.75rem;
-  justify-content: flex-end;
-  margin-top: auto;
-  
-  button {
-    padding: 0.5rem 1rem;
-    font-size: 0.9rem;
-    
+    &.file-picker-status {
+      .file-path {
+        font-family: var(--font-mono);
+        font-size: 0.85rem;
+        color: var(--color-text-light-4);
+        word-break: break-all;
+      }
+    }
+  }
+
+  .details-actions {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: auto;
+
+    .button {
+      display: flex;
+      align-items: center;
+      gap: 0.4rem;
+    }
+  }
+
+  .details-empty {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 0.75rem;
+    color: var(--color-text-light-6);
+
     i {
-      margin-right: 0.5rem;
-    }
-    
-    &.ss-button.primary {
-      background: var(--color-warm-2) !important;
-      color: white !important;
-      border-color: var(--color-warm-2) !important;
-      font-weight: 600;
-      
-      &:hover {
-        background: var(--color-warm-1) !important;
-        border-color: var(--color-warm-1) !important;
-        color: white !important;
-      }
-      
-      &:disabled {
-        opacity: 0.6;
-        background: var(--color-bg-alt) !important;
-        color: var(--color-text-light-secondary) !important;
-        border-color: var(--color-border-light-secondary) !important;
-      }
+      font-size: 2rem;
+      color: var(--color-text-light-5);
     }
   }
-}
 
-// Native Foundry pulse animation
-@keyframes foundry-pulse {
-  0%, 100% { 
-    opacity: 1; 
-    transform: scale(1);
-  }
-  50% { 
-    opacity: 0.7; 
-    transform: scale(1.05);
-  }
-}
+  .no-calendars {
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    color: var(--color-text-light-5);
+    text-align: center;
 
-// Current star glow animation
-@keyframes current-star-glow {
-  0% {
-    filter: drop-shadow(0 0 4px var(--color-warm-1));
-    transform: scale(1);
-  }
-  50% {
-    filter: drop-shadow(0 0 8px var(--color-warm-1)) drop-shadow(0 0 16px var(--color-warm-2));
-    transform: scale(1.1);
-  }
-  100% {
-    filter: drop-shadow(0 0 4px var(--color-warm-1));
-    transform: scale(1);
-  }
-}
-
-// Light theme overrides
-body.theme-light {
-  .seasons-stars.calendar-selection-dialog {
-    .calendar-badges {
-      .module-badge {
-        background: linear-gradient(135deg, var(--color-cool-4), var(--color-cool-3));
-        color: var(--color-text-dark-primary);
-        border: 1px solid var(--color-cool-2);
-      }
-      
-      .external-badge {
-        background: linear-gradient(135deg, var(--color-border-light-secondary), var(--color-border-light-tertiary));
-        color: var(--color-text-dark-primary);
-        border: 1px solid var(--color-border-light-primary);
-      }
+    .no-calendars-icon {
+      font-size: 2.5rem;
+      color: var(--color-text-light-6);
     }
   }
 }

--- a/packages/core/src/ui/calendar-selection-dialog.ts
+++ b/packages/core/src/ui/calendar-selection-dialog.ts
@@ -262,6 +262,27 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
       }
     }
 
+    if (sortedCalendars.length) {
+      const isFilePickerSelection = this.selectedCalendarId === '__FILE_PICKER__';
+      const hasValidSelection =
+        !!this.selectedCalendarId &&
+        sortedCalendars.some(calendar => calendar.id === this.selectedCalendarId);
+
+      if (!isFilePickerSelection && !hasValidSelection) {
+        const fallbackCalendar =
+          sortedCalendars.find(calendar => calendar.isCurrent) || sortedCalendars[0];
+
+        if (fallbackCalendar) {
+          this.selectedCalendarId = fallbackCalendar.id;
+        }
+      }
+
+      for (const calendar of sortedCalendars) {
+        calendar.isSelected = calendar.id === this.selectedCalendarId;
+        calendar.isCurrent = calendar.id === this.currentCalendarId;
+      }
+    }
+
     // Determine if file picker should be considered "selected"
     // Only show as selected if there's actually a file selected AND it's either the selected ID or is currently active
     const resultsCount = sortedCalendars.length;

--- a/packages/core/templates/calendar-selection-dialog.hbs
+++ b/packages/core/templates/calendar-selection-dialog.hbs
@@ -1,174 +1,239 @@
-<div class="dialog-content">
-  <form class="standard-form">
-    <div class="form-group">
-      <label>{{localize "SEASONS_STARS.dialog.calendar_selection.choose_calendar"}}</label>
-      <p class="hint">{{localize "SEASONS_STARS.dialog.calendar_selection.choose_hint"}}</p>
-      
-      <div class="form-fields">
-        <div class="calendar-selection-grid">
-          {{#each calendars}}
-          <div class="calendar-card ui-control {{#if isCurrent}}active{{/if}} {{#if isSelected}}picked{{/if}} {{#if isVariant}}variant{{/if}} {{#if hierarchyLevel}}hierarchy-level-{{hierarchyLevel}}{{/if}} source-{{sourceType}}" 
-               data-action="selectCalendar"
-               data-calendar-id="{{id}}" 
-               title="{{description}}">
-            
-            <div class="card-header flexcol">
-              <div class="calendar-title-row flexrow">
-                <div class="calendar-title-info flexcol">
-                  <h4 class="calendar-name">
-                    {{#if isVariant}}
-                    <span class="variant-indicator">
-                      <i class="fas fa-code-branch"></i>
-                    </span>
-                    {{/if}}
-                    {{label}}
-                  </h4>
-                  {{#if setting}}
-                  <span class="calendar-setting">{{setting}}</span>
-                  {{/if}}
-                  {{#if variantInfo}}
-                  <span class="variant-info">{{variantInfo}}</span>
-                  {{/if}}
-                </div>
-                <div class="calendar-badges flexrow">
-                  {{#if isCurrent}}
-                  <div class="current-badge" data-tooltip="Current active calendar">
-                    <i class="fas fa-star"></i>
-                  </div>
-                  {{/if}}
-                  {{#if isModuleSource}}
-                  <div class="module-badge" data-tooltip="{{sourceDescription}}">
-                    <i class="fas fa-puzzle-piece"></i>
-                  </div>
-                  {{else if isExternalSource}}
-                  <div class="external-badge" data-tooltip="{{sourceDescription}}">
-                    <i class="fas fa-cloud"></i>
-                  </div>
-                  {{/if}}
-                </div>
-              </div>
-              <div class="source-info flexrow">
-                <i class="{{sourceIcon}} source-icon"></i>
-                <span class="source-label">{{sourceLabel}}</span>
-              </div>
-            </div>
-
-            <div class="card-content flexcol">
-              <p class="calendar-description">{{description}}</p>
-              
-              <div class="preview-section">
-                <div class="sample-preview">
-                  <label>{{localize "SEASONS_STARS.dialog.calendar_selection.sample"}}:</label>
-                  <span class="sample-date">{{sampleDate}}</span>
-                </div>
-                
-                <div class="mini-preview">
-                  <label>Mini Widget:</label>
-                  <span class="mini-format">{{miniPreview}}</span>
-                </div>
-              </div>
-            </div>
-
-            <div class="card-actions flexrow">
-              <button type="button" data-action="previewCalendar" class="button" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.preview_tooltip'}}">
-                <i class="fas fa-eye"></i>
-                {{localize "SEASONS_STARS.dialog.calendar_selection.preview"}}
-              </button>
-              {{#if isSelected}}
-              <i class="fas fa-check-circle selected-indicator"></i>
-              {{/if}}
-            </div>
-          </div>
-          {{/each}}
-          
-          <!-- File Picker Card -->
-          <div class="calendar-card ui-control file-picker-card {{#if filePickerActive}}active{{/if}} {{#if filePickerSelected}}picked{{/if}}" 
-               {{#if selectedFilePath}}data-action="selectCalendar" data-calendar-id="__FILE_PICKER__"{{else}}data-action="openFilePicker"{{/if}}
-               title="{{localize 'SEASONS_STARS.dialog.calendar_selection.custom_file_hint'}}">
-            
-            <div class="card-header flexcol">
-              <div class="calendar-title-row flexrow">
-                <div class="calendar-title-info flexcol">
-                  <h4 class="calendar-name">
-                    <span class="file-picker-indicator">
-                      <i class="fas fa-folder-open"></i>
-                    </span>
-                    {{localize "SEASONS_STARS.dialog.calendar_selection.custom_file"}}
-                  </h4>
-                  {{#if selectedFilePath}}
-                  <span class="calendar-setting">{{selectedFilePath}}</span>
-                  {{/if}}
-                </div>
-                <div class="calendar-badges flexrow">
-                  {{#if filePickerActive}}
-                  <div class="current-badge" data-tooltip="Current active calendar">
-                    <i class="fas fa-star"></i>
-                  </div>
-                  {{/if}}
-                  <div class="file-badge" data-tooltip="Custom calendar file">
-                    <i class="fas fa-file-alt"></i>
-                  </div>
-                </div>
-              </div>
-              <div class="source-info flexrow">
-                <i class="fas fa-folder-open source-icon"></i>
-                <span class="source-label">Custom File</span>
-              </div>
-            </div>
-
-            <div class="card-content flexcol">
-              <p class="calendar-description">
-                {{#if selectedFilePath}}
-                  {{localize "SEASONS_STARS.dialog.calendar_selection.file_loaded"}}
-                {{else}}
-                  {{localize "SEASONS_STARS.dialog.calendar_selection.custom_file_hint"}}
-                {{/if}}
-              </p>
-              
-              <div class="preview-section">
-                {{#if selectedFilePath}}
-                <div class="sample-preview">
-                  <label>{{localize "SEASONS_STARS.dialog.calendar_selection.file_path"}}:</label>
-                  <span class="sample-date file-path">{{selectedFilePath}}</span>
-                </div>
-                {{else}}
-                <div class="sample-preview">
-                  <label>{{localize "SEASONS_STARS.dialog.calendar_selection.status"}}:</label>
-                  <span class="sample-date">{{localize "SEASONS_STARS.dialog.calendar_selection.click_to_select"}}</span>
-                </div>
-                {{/if}}
-              </div>
-            </div>
-
-            <div class="card-actions flexrow">
-              {{#if selectedFilePath}}
-              <button type="button" data-action="clearFilePicker" class="button" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.clear_file'}}">
-                <i class="fas fa-times"></i>
-                {{localize "SEASONS_STARS.dialog.calendar_selection.clear"}}
-              </button>
-              {{else}}
-              <button type="button" data-action="openFilePicker" class="button" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.browse_tooltip'}}">
-                <i class="fas fa-folder-open"></i>
-                {{localize "SEASONS_STARS.dialog.calendar_selection.browse"}}
-              </button>
-              {{/if}}
-              {{#if filePickerActive}}
-              <i class="fas fa-check-circle selected-indicator"></i>
-              {{/if}}
-            </div>
-          </div>
-        </div>
+<div class="dialog-content calendar-selection-master-detail">
+  <div class="calendar-selection-header flexcol">
+    <div class="header-title flexrow">
+      <span class="header-icon">
+        <i class="fas fa-calendar-alt"></i>
+      </span>
+      <div class="header-text flexcol">
+        <h1>{{localize 'SEASONS_STARS.dialog.calendar_selection.choose_calendar'}}</h1>
+        <p class="header-description">
+          {{localize 'SEASONS_STARS.dialog.calendar_selection.choose_hint'}}
+        </p>
       </div>
     </div>
-  </form>
+  </div>
+  {{#if calendarGroups.length}}
+  <div class="calendar-browser flexrow">
+    <div class="calendar-list-panel flexcol">
+      <div class="calendar-controls flexcol">
+        <div class="search-section">
+          <input
+            type="text"
+            class="calendar-search"
+            placeholder="{{localize 'SEASONS_STARS.dialog.calendar_selection.search_placeholder'}}"
+            value="{{searchQuery}}"
+            disabled
+          />
+        </div>
 
-  {{#unless calendars.length}}
+        <div class="filter-section flexrow">
+          <div class="filter-group">
+            <label>{{localize 'SEASONS_STARS.dialog.calendar_selection.filter_source_label'}}</label>
+            <div class="multi-select-dropdown disabled">
+              <button type="button" class="multi-select-trigger" disabled>
+                <span class="selected-text">{{localize 'SEASONS_STARS.dialog.calendar_selection.filter_source_all'}}</span>
+                <i class="fas fa-chevron-down"></i>
+              </button>
+            </div>
+          </div>
+
+          <div class="filter-group">
+            <label>{{localize 'SEASONS_STARS.dialog.calendar_selection.filter_tags_label'}}</label>
+            <input
+              type="text"
+              class="tag-filter-input"
+              placeholder="{{localize 'SEASONS_STARS.dialog.calendar_selection.filter_tags_placeholder'}}"
+              value="{{tagFilter}}"
+              disabled
+            />
+          </div>
+        </div>
+
+        <div class="filter-status">
+          <span class="results-count">
+            {{localize 'SEASONS_STARS.dialog.calendar_selection.results_count' count=resultsCount}}
+          </span>
+          <button
+            type="button"
+            class="clear-filters {{#unless filtersActive}}hidden{{/unless}}"
+            data-action="clearFilters"
+            disabled
+          >
+            <i class="fas fa-times"></i>
+            {{localize 'SEASONS_STARS.dialog.calendar_selection.clear_filters'}}
+          </button>
+        </div>
+      </div>
+
+      <div class="calendar-list scrollable">
+        {{#each calendarGroups}}
+        <div class="calendar-group">
+          <div class="group-header">
+            <i class="{{icon}} source-icon"></i>
+            <span class="source-name">{{label}}</span>
+            <span class="calendar-count">({{calendarCount}})</span>
+          </div>
+
+          <div class="calendar-items">
+            {{#each calendars}}
+            <div
+              class="calendar-item ui-control {{#if isCurrent}}current{{/if}} {{#if isSelected}}selected{{/if}} {{#if hierarchyLevel}}hierarchy-level-{{hierarchyLevel}}{{/if}} {{#if isFilePicker}}file-picker{{/if}}"
+              data-action="selectCalendar"
+              data-calendar-id="{{id}}"
+              tabindex="0"
+            >
+              <div class="calendar-item-content flexrow">
+                <div class="calendar-icon">
+                  <i class="{{sourceIcon}}"></i>
+                </div>
+
+                <div class="calendar-info flexcol">
+                  <div class="calendar-name">{{label}}</div>
+                  {{#if variantInfo}}
+                  <div class="variant-info">{{variantInfo}}</div>
+                  {{/if}}
+                  {{#if setting}}
+                  <div class="calendar-setting">{{setting}}</div>
+                  {{/if}}
+                  {{#if tags.length}}
+                  <div class="calendar-tags">
+                    {{#each tags}}
+                    <span class="tag">{{this}}</span>
+                    {{/each}}
+                  </div>
+                  {{/if}}
+                </div>
+
+                {{#if isCurrent}}
+                <div class="current-indicator" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.current'}}">
+                  <i class="fas fa-check-circle"></i>
+                </div>
+                {{/if}}
+              </div>
+            </div>
+            {{/each}}
+          </div>
+        </div>
+        {{/each}}
+      </div>
+
+      <div class="custom-calendar-actions">
+        <button type="button" class="add-custom-calendar" data-action="openFilePicker">
+          <i class="fas fa-plus"></i>
+          {{localize 'SEASONS_STARS.dialog.calendar_selection.add_custom_calendar'}}
+        </button>
+      </div>
+    </div>
+
+    <div class="calendar-details-panel flexcol">
+      <div class="calendar-details scrollable">
+        {{#if selectedCalendarDetails}}
+        <div class="details-header flexcol">
+          <h3 class="calendar-title">{{selectedCalendarDetails.label}}</h3>
+          {{#if selectedCalendarDetails.author}}
+          <div class="calendar-author">
+            <i class="fas fa-user"></i>
+            <span>{{selectedCalendarDetails.author}}</span>
+          </div>
+          {{/if}}
+          <div class="calendar-source">
+            <i class="{{selectedCalendarDetails.sourceIcon}} source-icon"></i>
+            <span>{{selectedCalendarDetails.sourceLabel}}</span>
+          </div>
+        </div>
+
+        <div class="details-section">
+          <h4>{{localize 'SEASONS_STARS.dialog.calendar_selection.description_header'}}</h4>
+          <p class="calendar-description">{{selectedCalendarDetails.description}}</p>
+        </div>
+
+        {{#if selectedCalendarDetails.tags.length}}
+        <div class="details-section">
+          <h4>{{localize 'SEASONS_STARS.dialog.calendar_selection.tags_header'}}</h4>
+          <div class="calendar-tags-display">
+            {{#each selectedCalendarDetails.tags}}
+            <span class="tag">{{this}}</span>
+            {{/each}}
+          </div>
+        </div>
+        {{/if}}
+
+        <div class="details-section">
+          <h4>{{localize 'SEASONS_STARS.dialog.calendar_selection.preview_header'}}</h4>
+          <div class="calendar-preview">
+            <div class="sample-preview">
+              <label>{{localize 'SEASONS_STARS.dialog.calendar_selection.preview_sample_label'}}</label>
+              <div class="sample-date">{{selectedCalendarDetails.sampleDate}}</div>
+            </div>
+
+            {{#if selectedCalendarDetails.miniPreview}}
+            <div class="mini-preview">
+              <label>{{localize 'SEASONS_STARS.dialog.calendar_selection.preview_mini_label'}}</label>
+              <div class="mini-format">{{selectedCalendarDetails.miniPreview}}</div>
+            </div>
+            {{/if}}
+          </div>
+        </div>
+
+        {{else}}
+        <div class="details-empty flexcol">
+          <i class="fas fa-calendar-plus"></i>
+          <p>{{localize 'SEASONS_STARS.dialog.calendar_selection.no_selection_message'}}</p>
+        </div>
+        {{/if}}
+
+        {{#if selectedCalendarDetails}}
+        <div class="details-actions">
+          {{#if selectedCalendarDetails.canPreview}}
+          <button
+            type="button"
+            class="button"
+            data-action="previewCalendar"
+            data-calendar-id="{{selectedCalendarDetails.id}}"
+          >
+            <i class="fas fa-eye"></i>
+            {{localize 'SEASONS_STARS.dialog.calendar_selection.preview'}}
+          </button>
+          {{/if}}
+
+          {{#if selectedCalendarDetails.isFilePicker}}
+            {{#if selectedCalendarDetails.hasFile}}
+            <button type="button" class="button" data-action="clearFilePicker">
+              <i class="fas fa-times"></i>
+              {{localize 'SEASONS_STARS.dialog.calendar_selection.clear'}}
+            </button>
+            {{else}}
+            <button type="button" class="button" data-action="openFilePicker">
+              <i class="fas fa-folder-open"></i>
+              {{localize 'SEASONS_STARS.dialog.calendar_selection.browse'}}
+            </button>
+            {{/if}}
+          {{/if}}
+        </div>
+
+        {{#if selectedCalendarDetails.isFilePicker}}
+        <div class="details-section file-picker-status">
+          <h4>{{localize 'SEASONS_STARS.dialog.calendar_selection.file_path'}}</h4>
+          <div class="file-path">
+            {{#if selectedCalendarDetails.selectedFilePath}}
+            {{selectedCalendarDetails.selectedFilePath}}
+            {{else}}
+            {{localize 'SEASONS_STARS.dialog.calendar_selection.no_file_selected'}}
+            {{/if}}
+          </div>
+        </div>
+        {{/if}}
+        {{/if}}
+      </div>
+    </div>
+  </div>
+  {{else}}
   <div class="no-calendars flexcol">
     <i class="fas fa-calendar-times no-calendars-icon"></i>
     <div class="no-calendars-message">
-      <h4>{{localize "SEASONS_STARS.dialog.calendar_selection.no_calendars"}}</h4>
-      <p>{{localize "SEASONS_STARS.dialog.calendar_selection.no_calendars_hint"}}</p>
+      <h4>{{localize 'SEASONS_STARS.dialog.calendar_selection.no_calendars'}}</h4>
+      <p>{{localize 'SEASONS_STARS.dialog.calendar_selection.no_calendars_hint'}}</p>
     </div>
   </div>
-  {{/unless}}
+  {{/if}}
 </div>

--- a/packages/core/templates/calendar-selection-dialog.hbs
+++ b/packages/core/templates/calendar-selection-dialog.hbs
@@ -34,6 +34,14 @@
                 <span class="selected-text">{{localize 'SEASONS_STARS.dialog.calendar_selection.filter_source_all'}}</span>
                 <i class="fas fa-chevron-down"></i>
               </button>
+              <div class="multi-select-options">
+                {{#each calendarGroups}}
+                <label class="multi-select-option">
+                  <input type="checkbox" value="{{id}}" disabled />
+                  <span>{{label}}</span>
+                </label>
+                {{/each}}
+              </div>
             </div>
           </div>
 

--- a/packages/core/test/calendar-selection-dialog-variants.test.ts
+++ b/packages/core/test/calendar-selection-dialog-variants.test.ts
@@ -196,8 +196,7 @@ describe('Calendar Selection Dialog - Variants Support', () => {
   });
 
   it('should generate proper variant info from variant IDs', async () => {
-    const context = await dialog._prepareContext();
-    const calendarsData = context.calendars;
+    await dialog._prepareContext();
 
     const testCases = [
       { id: 'calendar(simple-name)', expected: 'Variant: Simple Name' },
@@ -247,5 +246,16 @@ describe('Calendar Selection Dialog - Variants Support', () => {
     expect(gregorianCalendar.isVariant).toBe(false);
     expect(gregorianCalendar.variantInfo).toBe('');
     expect(gregorianCalendar.baseCalendarId).toBe('gregorian');
+  });
+
+  it('should default to the first available calendar when no current selection exists', async () => {
+    dialog = new CalendarSelectionDialog(calendars, '');
+    const context = await dialog._prepareContext();
+
+    expect(context.selectedCalendar).toBe('gregorian');
+    expect(context.selectedCalendarDetails?.id).toBe('gregorian');
+
+    const gregorianCalendar = context.calendars.find((c: any) => c.id === 'gregorian');
+    expect(gregorianCalendar?.isSelected).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- replace the calendar selection form grid with a master-detail layout that matches the mockup, including grouped sources, tag chips, and a detailed preview panel
- enhance the dialog logic to prepare grouped calendar data, expose file picker metadata, and keep the action buttons in sync with the current selection
- refresh the styling and localization strings so the dialog header, filters, and footer align with the new visual design

## Testing
- npm run lint
- npm run typecheck
- npm run test:run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1fd66d40c83278c401e116fb9fa0c