### PR TITLE
feat: add support for negative leap days

### DIFF
--- a/packages/core/src/core/calendar-engine.ts
+++ b/packages/core/src/core/calendar-engine.ts
@@ -852,14 +852,22 @@ export class CalendarEngine {
   private getMonthLengths(year: number): number[] {
     const monthLengths = this.calendar.months.map(month => month.days);
 
-    // Add leap year days if applicable
+    // Add or remove leap year days if applicable
     if (this.isLeapYear(year) && this.calendar.leapYear?.month) {
       const leapMonthIndex = this.calendar.months.findIndex(
         month => month.name === this.calendar.leapYear!.month
       );
 
       if (leapMonthIndex >= 0) {
-        monthLengths[leapMonthIndex] += this.calendar.leapYear!.extraDays || 1;
+        // extraDays can be positive (add days) or negative (remove days)
+        // Default to +1 for backward compatibility
+        const dayAdjustment = this.calendar.leapYear!.extraDays ?? 1;
+        monthLengths[leapMonthIndex] += dayAdjustment;
+
+        // Ensure month length doesn't go below 1
+        if (monthLengths[leapMonthIndex] < 1) {
+          monthLengths[leapMonthIndex] = 1;
+        }
       }
     }
 

--- a/packages/core/src/core/calendar-validator.ts
+++ b/packages/core/src/core/calendar-validator.ts
@@ -337,6 +337,19 @@ export class CalendarValidator {
         result.errors.push(
           `Leap year month '${calendar.leapYear.month}' does not exist in months list`
         );
+      } else if (calendar.leapYear.extraDays !== undefined) {
+        // Validate that negative leap days don't reduce month below 1 day
+        const targetMonth = calendar.months.find((m: any) => m.name === calendar.leapYear.month);
+        if (targetMonth && calendar.leapYear.extraDays < 0) {
+          const adjustedDays = targetMonth.days + calendar.leapYear.extraDays;
+          if (adjustedDays < 1) {
+            result.warnings.push(
+              `Leap year adjustment of ${calendar.leapYear.extraDays} days would reduce '${
+                calendar.leapYear.month
+              }' to ${adjustedDays} days (will be clamped to 1 day minimum)`
+            );
+          }
+        }
       }
     }
 

--- a/packages/core/src/types/calendar.d.ts
+++ b/packages/core/src/types/calendar.d.ts
@@ -41,6 +41,10 @@ export interface SeasonsStarsCalendar {
      */
     offset?: number;
     month?: string;
+    /**
+     * Number of days to add (positive) or remove (negative) during leap years.
+     * For example, +1 adds an extra day, -1 removes a day.
+     */
     extraDays?: number;
   };
 

--- a/packages/core/test/calendar-engine-leap-year-regression.test.ts
+++ b/packages/core/test/calendar-engine-leap-year-regression.test.ts
@@ -37,7 +37,7 @@ describe('Leap Year Calculation Regression', () => {
     const baseMonthDays = golarionCalendar.months.reduce((sum, m) => sum + m.days, 0);
 
     // Check leap year calculation
-    const leapYearExtra = isLeapYear ? golarionCalendar.leapYear.extraDays || 1 : 0;
+    const leapYearExtra = isLeapYear ? (golarionCalendar.leapYear.extraDays ?? 1) : 0;
 
     const expectedYearLength = baseMonthDays + leapYearExtra;
 

--- a/packages/core/test/calendar-engine-negative-leap-days.test.ts
+++ b/packages/core/test/calendar-engine-negative-leap-days.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Negative Leap Days Test
+ *
+ * This test ensures that the calendar engine correctly handles leap years
+ * that remove days from months (negative leap day adjustments).
+ *
+ * Tests scenarios where:
+ * - A leap year removes days instead of adding them
+ * - Month lengths are adjusted correctly (but never below 1)
+ * - Year length calculations account for negative adjustments
+ */
+
+import { describe, test, expect } from 'vitest';
+import { CalendarEngine } from '../src/core/calendar-engine';
+import type { SeasonsStarsCalendar } from '../src/types/calendar';
+
+describe('Negative Leap Days', () => {
+  test('Leap year removes one day from February', () => {
+    const calendar: SeasonsStarsCalendar = {
+      id: 'test-negative-leap',
+      translations: {},
+      year: {
+        epoch: 1,
+        currentYear: 2024,
+        prefix: '',
+        suffix: ' CE',
+        startDay: 1,
+      },
+      leapYear: {
+        rule: 'custom',
+        interval: 4,
+        month: 'February',
+        extraDays: -1, // Remove one day
+      },
+      months: [
+        { name: 'January', days: 31 },
+        { name: 'February', days: 29 }, // Normally 29, becomes 28 in leap years
+        { name: 'March', days: 31 },
+      ],
+      weekdays: [
+        { name: 'Monday' },
+        { name: 'Tuesday' },
+        { name: 'Wednesday' },
+        { name: 'Thursday' },
+        { name: 'Friday' },
+        { name: 'Saturday' },
+        { name: 'Sunday' },
+      ],
+      intercalary: [],
+      time: {
+        hoursInDay: 24,
+        minutesInHour: 60,
+        secondsInMinute: 60,
+      },
+    };
+
+    const engine = new CalendarEngine(calendar);
+
+    // 2024 is a leap year (divisible by 4)
+    // @ts-ignore - accessing private method
+    expect(engine.isLeapYear(2024)).toBe(true);
+
+    // @ts-ignore - accessing private method
+    const monthLengths2024 = engine.getMonthLengths(2024);
+    expect(monthLengths2024[1]).toBe(28); // February has 1 day removed
+
+    // @ts-ignore - accessing private method
+    const yearLength2024 = engine.getYearLength(2024);
+    expect(yearLength2024).toBe(31 + 28 + 31); // 90 days total
+
+    // 2025 is not a leap year
+    // @ts-ignore - accessing private method
+    expect(engine.isLeapYear(2025)).toBe(false);
+
+    // @ts-ignore - accessing private method
+    const monthLengths2025 = engine.getMonthLengths(2025);
+    expect(monthLengths2025[1]).toBe(29); // February has normal length
+
+    // @ts-ignore - accessing private method
+    const yearLength2025 = engine.getYearLength(2025);
+    expect(yearLength2025).toBe(31 + 29 + 31); // 91 days total
+  });
+
+  test('Leap year removes multiple days', () => {
+    const calendar: SeasonsStarsCalendar = {
+      id: 'test-multi-negative-leap',
+      translations: {},
+      year: {
+        epoch: 1,
+        currentYear: 2024,
+        prefix: '',
+        suffix: ' CE',
+        startDay: 1,
+      },
+      leapYear: {
+        rule: 'custom',
+        interval: 10,
+        month: 'December',
+        extraDays: -3, // Remove three days
+      },
+      months: [
+        { name: 'January', days: 30 },
+        { name: 'December', days: 30 },
+      ],
+      weekdays: [
+        { name: 'Monday' },
+        { name: 'Tuesday' },
+        { name: 'Wednesday' },
+        { name: 'Thursday' },
+        { name: 'Friday' },
+      ],
+      intercalary: [],
+      time: {
+        hoursInDay: 24,
+        minutesInHour: 60,
+        secondsInMinute: 60,
+      },
+    };
+
+    const engine = new CalendarEngine(calendar);
+
+    // 2030 is a leap year (divisible by 10)
+    // @ts-ignore - accessing private method
+    expect(engine.isLeapYear(2030)).toBe(true);
+
+    // @ts-ignore - accessing private method
+    const monthLengths2030 = engine.getMonthLengths(2030);
+    expect(monthLengths2030[1]).toBe(27); // December loses 3 days
+
+    // @ts-ignore - accessing private method
+    const yearLength2030 = engine.getYearLength(2030);
+    expect(yearLength2030).toBe(30 + 27); // 57 days total
+  });
+
+  test('Month length never goes below 1', () => {
+    const calendar: SeasonsStarsCalendar = {
+      id: 'test-extreme-negative',
+      translations: {},
+      year: {
+        epoch: 1,
+        currentYear: 2024,
+        prefix: '',
+        suffix: ' CE',
+        startDay: 1,
+      },
+      leapYear: {
+        rule: 'custom',
+        interval: 4,
+        month: 'Short',
+        extraDays: -10, // Try to remove more days than the month has
+      },
+      months: [
+        { name: 'Normal', days: 30 },
+        { name: 'Short', days: 5 }, // Only 5 days
+      ],
+      weekdays: [
+        { name: 'Day1' },
+        { name: 'Day2' },
+      ],
+      intercalary: [],
+      time: {
+        hoursInDay: 24,
+        minutesInHour: 60,
+        secondsInMinute: 60,
+      },
+    };
+
+    const engine = new CalendarEngine(calendar);
+
+    // 2024 is a leap year
+    // @ts-ignore - accessing private method
+    expect(engine.isLeapYear(2024)).toBe(true);
+
+    // @ts-ignore - accessing private method
+    const monthLengths = engine.getMonthLengths(2024);
+    expect(monthLengths[1]).toBe(1); // Should be clamped to 1, not negative
+
+    // @ts-ignore - accessing private method
+    const yearLength = engine.getYearLength(2024);
+    expect(yearLength).toBe(30 + 1); // 31 days total
+  });
+
+  test('Gregorian rule with negative days', () => {
+    const calendar: SeasonsStarsCalendar = {
+      id: 'test-gregorian-negative',
+      translations: {},
+      year: {
+        epoch: 1,
+        currentYear: 2000,
+        prefix: '',
+        suffix: ' CE',
+        startDay: 1,
+      },
+      leapYear: {
+        rule: 'gregorian',
+        month: 'February',
+        extraDays: -2, // Remove two days in leap years
+      },
+      months: [
+        { name: 'January', days: 31 },
+        { name: 'February', days: 30 }, // Normally 30, becomes 28 in leap years
+        { name: 'March', days: 31 },
+      ],
+      weekdays: [
+        { name: 'Monday' },
+        { name: 'Tuesday' },
+        { name: 'Wednesday' },
+        { name: 'Thursday' },
+        { name: 'Friday' },
+        { name: 'Saturday' },
+        { name: 'Sunday' },
+      ],
+      intercalary: [],
+      time: {
+        hoursInDay: 24,
+        minutesInHour: 60,
+        secondsInMinute: 60,
+      },
+    };
+
+    const engine = new CalendarEngine(calendar);
+
+    // 2000 is a leap year (divisible by 400)
+    // @ts-ignore - accessing private method
+    expect(engine.isLeapYear(2000)).toBe(true);
+    // @ts-ignore - accessing private method
+    const monthLengths2000 = engine.getMonthLengths(2000);
+    expect(monthLengths2000[1]).toBe(28); // February loses 2 days
+
+    // 1900 is NOT a leap year (divisible by 100 but not 400)
+    // @ts-ignore - accessing private method
+    expect(engine.isLeapYear(1900)).toBe(false);
+    // @ts-ignore - accessing private method
+    const monthLengths1900 = engine.getMonthLengths(1900);
+    expect(monthLengths1900[1]).toBe(30); // February keeps normal length
+
+    // 2004 is a leap year (divisible by 4, not by 100)
+    // @ts-ignore - accessing private method
+    expect(engine.isLeapYear(2004)).toBe(true);
+    // @ts-ignore - accessing private method
+    const monthLengths2004 = engine.getMonthLengths(2004);
+    expect(monthLengths2004[1]).toBe(28); // February loses 2 days
+  });
+});

--- a/packages/core/test/calendar-engine-negative-leap-regression.test.ts
+++ b/packages/core/test/calendar-engine-negative-leap-regression.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Negative Leap Days Regression Test with Existing Calendars
+ *
+ * This test ensures that the negative leap day feature works correctly
+ * with modifications to existing calendar definitions.
+ */
+
+import { describe, test, expect } from 'vitest';
+import { CalendarEngine } from '../src/core/calendar-engine';
+import type { SeasonsStarsCalendar } from '../src/types/calendar';
+import { loadTestCalendar } from './utils/calendar-loader';
+
+describe('Negative Leap Days with Existing Calendars', () => {
+  test('Gregorian calendar modified with negative leap days', () => {
+    // Load the standard Gregorian calendar
+    const gregorianBase: SeasonsStarsCalendar = loadTestCalendar('gregorian.json');
+
+    // Modify it to remove a day instead of adding one
+    const modifiedGregorian = {
+      ...gregorianBase,
+      leapYear: {
+        ...gregorianBase.leapYear,
+        extraDays: -1, // Remove a day in leap years instead of adding
+      },
+    };
+
+    const engine = new CalendarEngine(modifiedGregorian);
+
+    // 2024 is a leap year
+    // @ts-ignore - accessing private method
+    expect(engine.isLeapYear(2024)).toBe(true);
+
+    // @ts-ignore - accessing private method
+    const monthLengths2024 = engine.getMonthLengths(2024);
+    // February normally has 28 days, minus 1 for negative leap = 27
+    expect(monthLengths2024[1]).toBe(27);
+
+    // @ts-ignore - accessing private method
+    const yearLength2024 = engine.getYearLength(2024);
+    // Normal year is 365, removing 1 day = 364
+    expect(yearLength2024).toBe(364);
+
+    // 2023 is not a leap year
+    // @ts-ignore - accessing private method
+    expect(engine.isLeapYear(2023)).toBe(false);
+
+    // @ts-ignore - accessing private method
+    const monthLengths2023 = engine.getMonthLengths(2023);
+    expect(monthLengths2023[1]).toBe(28); // February has normal 28 days
+
+    // @ts-ignore - accessing private method
+    const yearLength2023 = engine.getYearLength(2023);
+    expect(yearLength2023).toBe(365); // Normal year length
+  });
+
+  test('Custom calendar with extreme negative adjustment', () => {
+    // Create a calendar where a month only has 2 days
+    const extremeCalendar: SeasonsStarsCalendar = {
+      id: 'extreme-test',
+      translations: {},
+      year: {
+        epoch: 1,
+        currentYear: 2000,
+        prefix: '',
+        suffix: '',
+        startDay: 1,
+      },
+      leapYear: {
+        rule: 'custom',
+        interval: 5,
+        month: 'Tiny',
+        extraDays: -5, // Try to remove 5 days from a 2-day month
+      },
+      months: [
+        { name: 'Normal', days: 30 },
+        { name: 'Tiny', days: 2 }, // Only 2 days!
+      ],
+      weekdays: [
+        { name: 'Day1' },
+        { name: 'Day2' },
+      ],
+      intercalary: [],
+      time: {
+        hoursInDay: 24,
+        minutesInHour: 60,
+        secondsInMinute: 60,
+      },
+    };
+
+    const engine = new CalendarEngine(extremeCalendar);
+
+    // 2000 is a leap year (divisible by 5)
+    // @ts-ignore - accessing private method
+    expect(engine.isLeapYear(2000)).toBe(true);
+
+    // @ts-ignore - accessing private method
+    const monthLengths = engine.getMonthLengths(2000);
+    // Should be clamped to minimum of 1 day
+    expect(monthLengths[1]).toBe(1);
+
+    // @ts-ignore - accessing private method
+    const yearLength = engine.getYearLength(2000);
+    expect(yearLength).toBe(31); // 30 + 1 (clamped)
+  });
+});

--- a/shared/schemas/calendar-v1.0.0.json
+++ b/shared/schemas/calendar-v1.0.0.json
@@ -274,9 +274,9 @@
         },
         "extraDays": {
           "type": "integer",
-          "minimum": 1,
+          "minimum": -10,
           "maximum": 10,
-          "description": "How many extra days to add"
+          "description": "Number of days to add (positive) or remove (negative) during leap years"
         }
       },
       "allOf": [


### PR DESCRIPTION
Adds the ability to remove days from months during leap years instead of only adding them.

This feature is useful for calendars where leap years involve removing extra days rather than adding them.

## Changes
- Updated type definitions to document negative extraDays
- Modified JSON schema to allow values from -10 to +10
- Enhanced calendar engine to handle both positive and negative adjustments
- Added safety check to prevent months from having less than 1 day
- Added validation warnings for extreme negative adjustments
- Comprehensive test coverage for the new functionality

Closes #303

Generated with [Claude Code](https://claude.ai/code)