### PR TITLE
feat: allow all users to access calendar widgets from scene controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9706,7 +9706,7 @@
     },
     "packages/core": {
       "name": "seasons-and-stars",
-      "version": "0.16.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/packages/core/src/ui/scene-controls.ts
+++ b/packages/core/src/ui/scene-controls.ts
@@ -28,11 +28,6 @@ export class SeasonsStarsSceneControls {
         notesToolsKeys: controls.notes?.tools ? Object.keys(controls.notes.tools) : null,
       });
 
-      if (!game.user?.isGM) {
-        Logger.debug('User is not GM, skipping scene control registration');
-        return;
-      }
-
       // Access notes controls directly (controls is an object, not array)
       if (controls.notes?.tools) {
         Logger.debug('Adding S&S scene control to notes.tools');

--- a/packages/core/test/ui-integration.test.ts
+++ b/packages/core/test/ui-integration.test.ts
@@ -305,12 +305,19 @@ describe('Scene Controls Integration', () => {
       });
     });
 
-    it('should not add scene control button for non-GM users', () => {
+    it('should add scene control button for non-GM users', () => {
       mockGame.user.isGM = false;
 
       sceneControlHandler(mockControls);
 
-      expect(mockControls.notes.tools['seasons-stars-widget']).toBeUndefined();
+      expect(mockControls.notes.tools['seasons-stars-widget']).toBeDefined();
+      expect(mockControls.notes.tools['seasons-stars-widget']).toEqual({
+        name: 'seasons-stars-widget',
+        title: 'SEASONS_STARS.calendar.toggle_calendar',
+        icon: 'fas fa-calendar-alt',
+        onChange: expect.any(Function),
+        button: true,
+      });
     });
 
     it('should handle missing notes controls gracefully', () => {


### PR DESCRIPTION
Closes #326

Remove GM-only restriction from scene controls button to allow players to view calendar widgets. Widget templates already properly hide GM-only mutation controls through existing permission flags.

## Changes
- Remove GM check from scene controls registration
- Update test to verify non-GM users can access scene controls
- All time manipulation controls remain GM-only through template flags

## Testing
- All 1473 tests passing
- Quality checks passed (lint, typecheck, build)

Generated with [Claude Code](https://claude.ai/code)