### PR TITLE
fix(calendar-builder): eliminate TypeScript build warnings

### DIFF
--- a/packages/core/src/types/foundry-v13-essentials.d.ts
+++ b/packages/core/src/types/foundry-v13-essentials.d.ts
@@ -390,6 +390,7 @@ declare class ApplicationV2<
     options: RenderOptions
   ): void;
   protected _onClose(options: ApplicationV2.CloseOptions): Promise<void>;
+  protected _onChangeForm(formConfig: any, event: Event): void;
 }
 
 declare namespace ApplicationV2 {

--- a/packages/custom-calendar-builder/src/calendar-builder-app.ts
+++ b/packages/custom-calendar-builder/src/calendar-builder-app.ts
@@ -2,6 +2,8 @@
  * Calendar Builder ApplicationV2 for creating and editing custom calendars
  */
 
+/// <reference types="../../core/src/types/foundry-v13-essentials" />
+
 export class CalendarBuilderApp extends foundry.applications.api.HandlebarsApplicationMixin(
   foundry.applications.api.ApplicationV2
 ) {
@@ -15,7 +17,7 @@ export class CalendarBuilderApp extends foundry.applications.api.HandlebarsAppli
   }
 
   /** @override */
-  async close(options?: any): Promise<void> {
+  async close(options?: any): Promise<this> {
     // Clean up validation timeout
     if (this.validationTimeout) {
       clearTimeout(this.validationTimeout);
@@ -79,9 +81,8 @@ export class CalendarBuilderApp extends foundry.applications.api.HandlebarsAppli
     this._updateValidationDisplay();
   }
 
-  /** @override */
-  _onChangeForm(formConfig: any, event: Event): void {
-    super._onChangeForm?.(formConfig, event);
+  protected override _onChangeForm(formConfig: any, event: Event): void {
+    super._onChangeForm(formConfig, event);
 
     // Update current JSON from the CodeMirror element
     const codeMirror = this.element?.querySelector('#calendar-json-editor') as any;
@@ -417,7 +418,7 @@ export class CalendarBuilderApp extends foundry.applications.api.HandlebarsAppli
   async _onClearEditor(event: Event, target: HTMLElement): Promise<void> {
     try {
       const confirmed = await foundry.applications.api.DialogV2.confirm({
-        window: { title: 'Confirm Clear' },
+        title: 'Confirm Clear',
         content: game.i18n.localize('CALENDAR_BUILDER.app.dialogs.confirm_clear'),
         rejectClose: false,
         modal: true

--- a/packages/custom-calendar-builder/src/module.ts
+++ b/packages/custom-calendar-builder/src/module.ts
@@ -3,6 +3,8 @@
  * Provides a user interface for creating and editing custom calendar JSON files
  */
 
+/// <reference types="../../core/src/types/foundry-v13-essentials" />
+
 import { CalendarBuilderApp } from './calendar-builder-app';
 
 let calendarBuilderApp: CalendarBuilderApp | null = null;

--- a/rollup.config.calendar-builder.js
+++ b/rollup.config.calendar-builder.js
@@ -14,6 +14,7 @@ export default {
     nodeResolve(),
     commonjs(),
     typescript({
+      tsconfig: '../../tsconfig.json',
       include: ['src/**/*'],
       compilerOptions: {
         target: 'ES2020',


### PR DESCRIPTION
## Summary
Resolves all TypeScript warnings during calendar-builder package build by properly referencing shared Foundry type definitions from core package.

## Changes
- **rollup.config.calendar-builder.js**: Add tsconfig reference for proper typeRoots resolution
- **calendar-builder-app.ts & module.ts**: Add triple-slash directives to reference core Foundry types
- **foundry-v13-essentials.d.ts**: Extend ApplicationV2 types with `_onChangeForm` method
- **calendar-builder-app.ts**: 
  - Fix `close()` return type from `Promise<void>` to `Promise<this>`
  - Use proper `override` keyword with `protected` visibility for `_onChangeForm()`
  - Fix `DialogV2.confirm()` to use `title` instead of `window: { title }`

## Benefits
- Zero TypeScript warnings during build
- All type definitions shared from core package - no duplication
- Proper use of TypeScript override mechanism
- Maintains compatibility with Foundry ApplicationV2 API

## Testing
- ✅ `npm run build` completes with no TypeScript warnings
- ✅ All lint-staged hooks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)