### PR TITLE
feat(ui): improve main calendar widget layout and styling

### DIFF
--- a/packages/core/src/styles/calendar-widget.scss
+++ b/packages/core/src/styles/calendar-widget.scss
@@ -39,80 +39,39 @@
   // Calendar header
   .calendar-header {
     border-bottom: 1px solid var(--color-border-light-primary);
-    padding-bottom: 6px;
+    padding: 8px;
     display: flex;
-    flex-direction: column;
-    gap: 6px;
+    align-items: center;
+    gap: 8px;
+    background: var(--color-bg-alt);
 
-    .calendar-title {
-      display: flex;
-      align-items: center;
-      gap: 6px;
-      cursor: pointer;
-      padding: 6px 8px;
-      border-radius: 4px;
-      transition: all 0.2s;
+    .calendar-name {
+      flex: 1;
       font-weight: 600;
       color: var(--color-text-light-primary);
-      border: 1px solid var(--color-border-light-primary);
-      background: var(--color-bg-alt);
-
-      &.clickable:hover {
-        background: var(--color-bg-option);
-        border-color: var(--color-border-light-secondary);
-        transform: translateY(-1px);
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      }
-
-      i:first-child {
-        color: var(--color-text-light-heading);
-      }
-
-      .dropdown-icon {
-        margin-left: auto;
-        font-size: 0.8em;
-        opacity: 0.8;
-        transition: transform 0.2s;
-      }
-
-      &.clickable:hover .dropdown-icon {
-        transform: translateY(1px);
-        opacity: 1;
-      }
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
-    .calendar-hint {
-      font-size: 0.75em;
-      color: var(--color-text-light-secondary);
-      margin-top: 4px;
-      padding: 2px 8px;
-      text-align: center;
-      opacity: 0.8;
-      font-style: italic;
-    }
-
-    .calendar-setting {
-      font-size: 0.8em;
-      color: var(--color-text-light-secondary);
-      margin-top: 2px;
-      padding-left: 22px;
-    }
-
-    .widget-switching-controls {
+    .header-controls {
       display: flex;
       gap: 4px;
-      justify-content: center;
-      margin-top: 4px;
+      flex-shrink: 0;
 
-      .widget-switch-btn {
+      .header-control-btn {
         background: var(--color-bg-btn);
         border: 1px solid var(--color-border-dark);
         border-radius: 3px;
         padding: 4px 8px;
         cursor: pointer;
-        font-size: 0.8em;
         color: var(--color-text-primary);
         transition: all 0.15s ease;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-width: 28px;
+        height: 28px;
 
         &:hover {
           background: var(--color-bg-btn-hover);
@@ -125,32 +84,60 @@
         }
 
         i {
-          margin-right: 4px;
+          font-size: 0.9em;
         }
       }
     }
   }
 
-  // Date display
+  // Date display (well/inset style)
   .date-display {
     cursor: pointer;
-    padding: 8px;
+    padding: 20px;
+    margin: 8px;
     border-radius: 6px;
-    background: var(--color-bg-alt);
-    border: 1px solid var(--color-border-light-primary);
+    border: 2px solid var(--color-border-dark);
     transition: all 0.2s;
 
-    &:hover {
-      background: var(--color-bg-option);
-      border-color: var(--color-border-light-secondary);
+    // Light theme: darker inset
+    body.theme-light & {
+      background: rgba(0, 0, 0, 0.15);
+      box-shadow:
+        inset 0 2px 4px rgba(0, 0, 0, 0.3),
+        inset 0 -1px 2px rgba(255, 255, 255, 0.1);
+
+      &:hover {
+        background: rgba(0, 0, 0, 0.2);
+        border-color: var(--color-border-light-secondary);
+        box-shadow:
+          inset 0 2px 4px rgba(0, 0, 0, 0.4),
+          inset 0 -1px 2px rgba(255, 255, 255, 0.15);
+      }
+    }
+
+    // Dark theme: lighter inset
+    body.theme-dark & {
+      background: rgba(255, 255, 255, 0.08);
+      box-shadow:
+        inset 0 2px 4px rgba(0, 0, 0, 0.5),
+        inset 0 -1px 2px rgba(255, 255, 255, 0.1);
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.12);
+        border-color: var(--color-border-light-secondary);
+        box-shadow:
+          inset 0 2px 4px rgba(0, 0, 0, 0.6),
+          inset 0 -1px 2px rgba(255, 255, 255, 0.15);
+      }
     }
 
     .main-date {
-      font-size: 1.1em;
-      font-weight: 600;
+      font-size: 1.3em;
+      font-weight: 700;
       color: var(--color-text-light-primary);
       text-align: center;
-      margin-bottom: 4px;
+      margin-bottom: 8px;
+      letter-spacing: 0.5px;
     }
 
     .time-display {
@@ -161,11 +148,12 @@
 
       .time {
         font-family: var(--font-mono);
-        font-size: 1em;
+        font-size: 1.1em;
+        font-weight: 500;
         color: var(--color-text-light-secondary);
-        background: var(--color-bg);
-        padding: 2px 6px;
-        border-radius: 3px;
+        background: var(--color-bg-alt);
+        padding: 4px 12px;
+        border-radius: 4px;
         border: 1px solid var(--color-border-light-tertiary);
       }
 
@@ -264,13 +252,90 @@
         }
 
         &[data-unit="months"] {
-          background: linear-gradient(135deg, #dc2626, #ef4444);
+          background: linear-gradient(135deg, #0891b2, #06b6d4);
           color: white;
-          border-color: #dc2626;
+          border-color: #0891b2;
 
           &:hover {
-            background: linear-gradient(135deg, #991b1b, #dc2626);
+            background: linear-gradient(135deg, #0e7490, #0891b2);
             transform: translateY(-2px);
+          }
+        }
+      }
+
+      // Time buttons (for quick time controls)
+      .time-buttons {
+        display: flex;
+        flex-direction: row;
+        gap: 6px;
+        flex-wrap: wrap;
+
+        button {
+          flex: 1;
+          min-width: 60px;
+          padding: 6px 8px;
+          font-size: 0.75em;
+
+          // Advance button styling (override data-unit gradients for consistency)
+          &:not(.rewind) {
+            background: linear-gradient(135deg, #10b981, #14b8a6) !important;
+            border-color: #10b981 !important;
+            color: white !important;
+
+            &:hover {
+              background: linear-gradient(135deg, #059669, #0d9488) !important;
+              border-color: #059669 !important;
+              color: white !important;
+            }
+          }
+
+          // Rewind button styling
+          &.rewind {
+            background: linear-gradient(135deg, #dc2626, #ef4444) !important;
+            border-color: #dc2626 !important;
+            color: white !important;
+
+            &:hover {
+              background: linear-gradient(135deg, #b91c1c, #dc2626) !important;
+              border-color: #b91c1c !important;
+              color: white !important;
+            }
+
+            &:active {
+              background: linear-gradient(135deg, #991b1b, #b91c1c) !important;
+            }
+          }
+        }
+      }
+
+      // Date buttons (for date advance controls)
+      .date-buttons {
+        display: flex;
+        flex-direction: row;
+        gap: 6px;
+        flex-wrap: wrap;
+
+        button {
+          flex: 1;
+          min-width: 80px;
+          padding: 6px 8px;
+          font-size: 0.75em;
+
+          // Rewind button styling
+          &.rewind {
+            background: linear-gradient(135deg, #dc2626, #ef4444) !important;
+            border-color: #dc2626 !important;
+            color: white !important;
+
+            &:hover {
+              background: linear-gradient(135deg, #b91c1c, #dc2626) !important;
+              border-color: #b91c1c !important;
+              color: white !important;
+            }
+
+            &:active {
+              background: linear-gradient(135deg, #991b1b, #b91c1c) !important;
+            }
           }
         }
       }
@@ -284,51 +349,6 @@
         label {
           margin-bottom: 0;
           flex-shrink: 0;
-        }
-
-        .time-buttons {
-          display: flex;
-          flex-direction: row;
-          gap: 6px;
-          flex-wrap: wrap;
-          flex: 1;
-          
-          button {
-            flex: 1;
-            min-width: 60px;
-            padding: 6px 8px;
-            font-size: 0.75em;
-            
-            // Advance button styling (override data-unit gradients for consistency)
-            &:not(.rewind) {
-              background: linear-gradient(135deg, #10b981, #14b8a6) !important;
-              border-color: #10b981 !important;
-              color: white !important;
-              
-              &:hover {
-                background: linear-gradient(135deg, #059669, #0d9488) !important;
-                border-color: #059669 !important;
-                color: white !important;
-              }
-            }
-            
-            // Rewind button styling
-            &.rewind {
-              background: linear-gradient(135deg, #dc2626, #ef4444);
-              border-color: #dc2626;
-              color: white;
-              
-              &:hover {
-                background: linear-gradient(135deg, #b91c1c, #dc2626);
-                border-color: #b91c1c;
-                color: white;
-              }
-              
-              &:active {
-                background: linear-gradient(135deg, #991b1b, #b91c1c);
-              }
-            }
-          }
         }
       }
     }
@@ -425,10 +445,6 @@
       // Date advance section inherits control-group styles
     }
 
-    .bulk-advance-section {
-      // Bulk advance section inherits control-group styles
-    }
-
     // Error test section styling
     .error-test-section {
       border-top: 1px dashed var(--color-border-light-primary);
@@ -498,31 +514,37 @@
       display: flex;
       align-items: center;
       gap: 6px;
-      padding: 6px 10px;
-      font-size: 0.8em;
-      border: 1px solid var(--color-border-light-secondary);
-      background: var(--color-bg);
+      padding: 8px 12px;
+      font-size: 0.85em;
+      border: 2px solid var(--color-border-light-secondary);
+      background: linear-gradient(to bottom, var(--color-bg-btn), var(--color-bg));
       color: var(--color-text-light-primary);
-      border-radius: 4px;
+      border-radius: 5px;
       cursor: pointer;
-      transition: all 0.2s;
-      font-weight: 500;
+      transition: all 0.15s ease;
+      font-weight: 600;
+      box-shadow: 0 2px 5px rgba(0, 0, 0, 0.25);
 
       &:hover {
         background: var(--color-text-light-highlight);
         color: var(--color-text-dark-primary);
         border-color: var(--color-text-light-highlight);
-        transform: translateY(-1px);
-        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        transform: translateY(-2px);
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
       }
 
       &:active {
         transform: translateY(0);
-        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
       }
 
       i {
-        font-size: 0.9em;
+        font-size: 1em;
+        flex-shrink: 0;
+      }
+
+      .sidebar-button-text {
+        flex: 1;
       }
     }
   }

--- a/packages/core/src/styles/calendar-widget.scss
+++ b/packages/core/src/styles/calendar-widget.scss
@@ -275,35 +275,18 @@
           min-width: 60px;
           padding: 6px 8px;
           font-size: 0.75em;
+        }
 
-          // Advance button styling (override data-unit gradients for consistency)
-          &:not(.rewind) {
-            background: linear-gradient(135deg, #10b981, #14b8a6) !important;
-            border-color: #10b981 !important;
-            color: white !important;
+        // Advance button styling (override data-unit gradients for consistency)
+        button:not(.rewind) {
+          background: linear-gradient(135deg, #10b981, #14b8a6);
+          border-color: #10b981;
+          color: white;
 
-            &:hover {
-              background: linear-gradient(135deg, #059669, #0d9488) !important;
-              border-color: #059669 !important;
-              color: white !important;
-            }
-          }
-
-          // Rewind button styling
-          &.rewind {
-            background: linear-gradient(135deg, #dc2626, #ef4444) !important;
-            border-color: #dc2626 !important;
-            color: white !important;
-
-            &:hover {
-              background: linear-gradient(135deg, #b91c1c, #dc2626) !important;
-              border-color: #b91c1c !important;
-              color: white !important;
-            }
-
-            &:active {
-              background: linear-gradient(135deg, #991b1b, #b91c1c) !important;
-            }
+          &:hover {
+            background: linear-gradient(135deg, #059669, #0d9488);
+            border-color: #059669;
+            color: white;
           }
         }
       }
@@ -320,23 +303,24 @@
           min-width: 80px;
           padding: 6px 8px;
           font-size: 0.75em;
+        }
+      }
 
-          // Rewind button styling
-          &.rewind {
-            background: linear-gradient(135deg, #dc2626, #ef4444) !important;
-            border-color: #dc2626 !important;
-            color: white !important;
+      // Shared rewind button styling for both time and date controls
+      .time-buttons button.rewind,
+      .date-buttons button.rewind {
+        background: linear-gradient(135deg, #dc2626, #ef4444);
+        border-color: #dc2626;
+        color: white;
 
-            &:hover {
-              background: linear-gradient(135deg, #b91c1c, #dc2626) !important;
-              border-color: #b91c1c !important;
-              color: white !important;
-            }
+        &:hover {
+          background: linear-gradient(135deg, #b91c1c, #dc2626);
+          border-color: #b91c1c;
+          color: white;
+        }
 
-            &:active {
-              background: linear-gradient(135deg, #991b1b, #b91c1c) !important;
-            }
-          }
+        &:active {
+          background: linear-gradient(135deg, #991b1b, #b91c1c);
         }
       }
 

--- a/packages/core/src/ui/calendar-widget.ts
+++ b/packages/core/src/ui/calendar-widget.ts
@@ -30,14 +30,13 @@ export class CalendarWidget extends foundry.applications.api.HandlebarsApplicati
       resizable: false,
     },
     position: {
-      width: 280,
+      width: 320,
       height: 'auto' as const,
     },
     actions: {
       openCalendarSelection: CalendarWidget.prototype._onOpenCalendarSelection,
       openDetailedView: CalendarWidget.prototype._onOpenDetailedView,
       advanceDate: CalendarWidget.prototype._onAdvanceDate,
-      openBulkAdvance: CalendarWidget.prototype._onOpenBulkAdvance,
       clickSidebarButton: CalendarWidget.prototype._onClickSidebarButton,
       switchToMini: CalendarWidget.prototype._onSwitchToMini,
       switchToGrid: CalendarWidget.prototype._onSwitchToGrid,
@@ -272,16 +271,6 @@ export class CalendarWidget extends foundry.applications.api.HandlebarsApplicati
       Logger.error('Error advancing date', error as Error);
       ui.notifications?.error('Failed to advance date');
     }
-  }
-
-  /**
-   * Instance action handler for opening bulk advance dialog
-   */
-  async _onOpenBulkAdvance(event: Event, _target: HTMLElement): Promise<void> {
-    event.preventDefault();
-
-    // Show placeholder for now - will implement proper dialog later
-    ui.notifications?.info('Bulk time advancement coming soon!');
   }
 
   /**

--- a/packages/core/templates/calendar-widget-sidebar.hbs
+++ b/packages/core/templates/calendar-widget-sidebar.hbs
@@ -5,11 +5,12 @@
       <button
         type="button"
         class="sidebar-button"
-        title="{{this.tooltip}}"
+        title="{{#if this.tooltip}}{{this.tooltip}}{{else}}{{this.name}}{{/if}}"
         data-action="clickSidebarButton"
         data-button-name="{{this.name}}"
       >
         <i class="{{this.icon}}"></i>
+        <span class="sidebar-button-text">{{#if this.tooltip}}{{this.tooltip}}{{else}}{{this.name}}{{/if}}</span>
       </button>
     {{/each}}
   </div>

--- a/packages/core/templates/calendar-widget.hbs
+++ b/packages/core/templates/calendar-widget.hbs
@@ -8,25 +8,20 @@
   {{else}}
     {{!-- Calendar Header --}}
     <div class="calendar-header">
-      <div class="calendar-title {{#if isGM}}clickable{{/if}}" {{#if isGM}}data-action="openCalendarSelection" title="Click to change calendar system"{{/if}}>
-        <i class="fas fa-calendar-alt"></i>
-        <span>{{calendar.label}}</span>
-        {{#if isGM}}<i class="fas fa-chevron-down dropdown-icon"></i>{{/if}}
-      </div>
-      <div class="widget-switching-controls">
-        <button type="button" class="widget-switch-btn" data-action="switchToMini" title="Switch to Mini Widget">
+      <span class="calendar-name">{{calendar.label}}</span>
+      <div class="header-controls">
+        <button type="button" class="header-control-btn" data-action="switchToMini" title="Switch to Mini Widget">
           <i class="fas fa-compress-alt"></i>
         </button>
-        <button type="button" class="widget-switch-btn" data-action="switchToGrid" title="Switch to Grid Widget">
+        <button type="button" class="header-control-btn" data-action="switchToGrid" title="Switch to Grid Widget">
           <i class="fas fa-th"></i>
         </button>
+        {{#if isGM}}
+        <button type="button" class="header-control-btn" data-action="openCalendarSelection" title="Change Calendar System">
+          <i class="fas fa-cog"></i>
+        </button>
+        {{/if}}
       </div>
-      {{#if isGM}}
-        <div class="calendar-hint">Click above to change calendar</div>
-      {{/if}}
-      {{#if calendar.setting}}
-        <div class="calendar-setting">{{calendar.setting}}</div>
-      {{/if}}
     </div>
 
     {{!-- Date Display --}}
@@ -60,12 +55,12 @@
         {{!-- Existing time controls continue below --}}
         {{#if showTimeControls}}
           <div class="time-advance-section">
-            <div class="control-group horizontal">
+            <div class="control-group">
               <label>Quick Time:</label>
               <div class="time-buttons">
                 {{#each (getQuickTimeButtons false)}}
-                  <button data-action="advanceDate" 
-                          data-amount="{{this.amount}}" 
+                  <button data-action="advanceDate"
+                          data-amount="{{this.amount}}"
                           data-unit="{{this.unit}}"
                           class="{{#if (lt this.amount 0)}}rewind{{/if}}"
                           title="{{#if (lt this.amount 0)}}Go back{{else}}Advance{{/if}} {{this.label}}">
@@ -79,25 +74,29 @@
 
         <div class="date-advance-section">
           <div class="control-group">
-            <label>Advance Date:</label>
-            <button data-action="advanceDate" data-amount="1" data-unit="days" title="Advance 1 day">
-              <i class="fas fa-plus"></i> 1 Day
-            </button>
-            <button data-action="advanceDate" data-amount="1" data-unit="weeks" title="Advance 1 week">
-              <i class="fas fa-plus"></i> 1 Week
-            </button>
-            <button data-action="advanceDate" data-amount="1" data-unit="months" title="Advance 1 month">
-              <i class="fas fa-plus"></i> 1 Month
-            </button>
-          </div>
-        </div>
-
-        <div class="bulk-advance-section">
-          <div class="control-group">
-            <label>Bulk Advance:</label>
-            <button data-action="openBulkAdvance" title="Open bulk time advancement dialog">
-              <i class="fas fa-fast-forward"></i> Custom
-            </button>
+            <label>Date Controls:</label>
+            <div class="date-buttons">
+              <button data-action="advanceDate" data-amount="1" data-unit="days" title="Advance 1 day">
+                <i class="fas fa-plus"></i> 1 Day
+              </button>
+              <button data-action="advanceDate" data-amount="1" data-unit="weeks" title="Advance 1 week">
+                <i class="fas fa-plus"></i> 1 Week
+              </button>
+              <button data-action="advanceDate" data-amount="1" data-unit="months" title="Advance 1 month">
+                <i class="fas fa-plus"></i> 1 Month
+              </button>
+            </div>
+            <div class="date-buttons">
+              <button data-action="advanceDate" data-amount="-1" data-unit="days" class="rewind" title="Go back 1 day">
+                <i class="fas fa-minus"></i> 1 Day
+              </button>
+              <button data-action="advanceDate" data-amount="-1" data-unit="weeks" class="rewind" title="Go back 1 week">
+                <i class="fas fa-minus"></i> 1 Week
+              </button>
+              <button data-action="advanceDate" data-amount="-1" data-unit="months" class="rewind" title="Go back 1 month">
+                <i class="fas fa-minus"></i> 1 Month
+              </button>
+            </div>
           </div>
         </div>
 

--- a/packages/core/test/calendar-widget-gm-permissions.test.ts
+++ b/packages/core/test/calendar-widget-gm-permissions.test.ts
@@ -106,7 +106,6 @@ describe('CalendarWidget GM permissions', () => {
     expect(context.isGM).toBe(true);
     let html = template(context);
     expect(html).toContain('data-action="openCalendarSelection"');
-    expect(html).toContain('calendar-hint');
 
     // Player view
     game.user = { isGM: false } as any;
@@ -114,7 +113,6 @@ describe('CalendarWidget GM permissions', () => {
     expect(context.isGM).toBe(false);
     html = template(context);
     expect(html).not.toContain('data-action="openCalendarSelection"');
-    expect(html).not.toContain('calendar-hint');
   });
 
   it('prevents non-GMs from advancing time via _onAdvanceDate', async () => {


### PR DESCRIPTION
## Summary

Implements UI improvements from issue #35 to enhance the main calendar widget's visual design and usability.

## Changes

### Header and Layout
- ✅ Consolidate header controls into single horizontal row
- ✅ Remove redundant calendar icon (already on window frame)
- ✅ Increase widget width from 280px to 320px for better layout
- ✅ Remove calendar setting row (not needed in widget)

### Date/Time Display
- ✅ Add theme-specific well/inset effect for date/time display
  - Light theme: darker inset background (`rgba(0, 0, 0, 0.15)`)
  - Dark theme: lighter inset background (`rgba(255, 255, 255, 0.08)`)

### Time Controls
- ✅ Change Quick Time buttons from horizontal to vertical layout
- ✅ Add Date Controls section with balanced advance/reverse buttons
  - First row: advance buttons (day, week, month)
  - Second row: reverse buttons (day, week, month)
- ✅ Change month advance color from red to cyan to avoid color clash with rewind buttons
- ✅ Remove bulk advance button (unimplemented placeholder, made redundant by configurable Quick Time buttons)

### Sidebar Buttons
- ✅ Add descriptive text to sidebar buttons (shows tooltip or button name as fallback)
- ✅ Improve visual styling with gradients, stronger shadows, and better hover effects

## Screenshots

_Testing in Foundry VTT recommended to see the full effect of theme-specific styling_

## Related Issues

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)