### PR TITLE
feat: redesign calendar selection dialog with two-column master-detail layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9962,7 +9962,7 @@
     },
     "packages/core": {
       "name": "seasons-and-stars",
-      "version": "0.19.0",
+      "version": "0.20.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -10037,7 +10037,7 @@
     },
     "packages/custom-calendar-builder": {
       "name": "seasons-and-stars-calendar-builder",
-      "version": "0.1.0",
+      "version": "0.2.4",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/packages/core/languages/en.json
+++ b/packages/core/languages/en.json
@@ -36,6 +36,7 @@
         "custom_file_hint": "Select a custom calendar JSON file from your Foundry server. This allows you to use calendars that aren't included in the built-in collection.",
         "browse": "Browse",
         "browse_tooltip": "Select a custom calendar file from your Foundry server",
+        "browse_for_file": "Browse for calendar file...",
         "no_file_selected": "No custom file selected",
         "clear_file": "Clear file selection",
         "clear": "Clear",
@@ -43,7 +44,17 @@
         "file_loaded": "Custom calendar file is loaded and ready to use",
         "file_path": "File Path",
         "status": "Status",
-        "click_to_select": "Click to select a calendar file"
+        "click_to_select": "Click to select a calendar file",
+        "available_calendars": "Available Calendars",
+        "description": "Description",
+        "date_formats": "Date Formats",
+        "full_widget": "Full Widget Format",
+        "mini_widget": "Mini Widget Format",
+        "source_info": "Source Information",
+        "references": "References",
+        "author": "Author",
+        "tags": "Tags",
+        "select_to_view": "Select a calendar to view details"
       },
       "calendar_preview": {
         "title": "Calendar Preview: {calendar}"

--- a/packages/core/src/styles/calendar-selection-dialog.scss
+++ b/packages/core/src/styles/calendar-selection-dialog.scss
@@ -1,698 +1,511 @@
 /**
- * Calendar Selection Dialog - Native Foundry Integration
+ * Calendar Selection Dialog - Two-Column Master-Detail Layout
  */
 
 .seasons-stars.calendar-selection-dialog {
-  // Use native Foundry CSS Grid system with scrolling
-  .calendar-selection-grid {
+  // Two-column layout inspired by calendar builder
+  .calendar-selection-layout {
     display: grid;
-    grid-template-columns: 1fr; // Single column for wider cards
-    gap: 1.25rem;
-    min-height: 300px;
-    max-height: 520px;
-    overflow-y: auto;
-    overflow-x: hidden;
-    padding: 0.5rem 0.75rem 0.5rem 0.5rem; // Better padding with scrollbar space
-    
-    // Ensure smooth scrolling
-    scroll-behavior: smooth;
-    
-    // Enhanced scrollbar styling for Foundry
-    &::-webkit-scrollbar {
-      width: 8px;
-    }
-    
-    &::-webkit-scrollbar-track {
-      background: var(--color-bg-alt);
-      border-radius: 4px;
-      margin: 4px 0;
-    }
-    
-    &::-webkit-scrollbar-thumb {
-      background: linear-gradient(180deg, var(--color-border-light-secondary), var(--color-border-light-tertiary));
-      border-radius: 4px;
-      border: 1px solid var(--color-bg-alt);
-      
-      &:hover {
-        background: linear-gradient(180deg, var(--color-border-light-primary), var(--color-border-light-secondary));
-      }
-      
-      &:active {
-        background: var(--color-warm-3);
-      }
-    }
-    
-    // Add subtle fade effect at top/bottom when scrolling
-    &::before, &::after {
-      content: '';
-      position: sticky;
-      display: block;
-      height: 8px;
-      margin: 0 -0.5rem;
-      z-index: 1;
-      pointer-events: none;
-    }
-    
-    &::before {
-      top: 0;
-      background: linear-gradient(to bottom, var(--color-bg-option), transparent);
-    }
-    
-    &::after {
-      bottom: 0;
-      background: linear-gradient(to top, var(--color-bg-option), transparent);
-    }
-  }
-
-  // Calendar cards using native ui-control pattern
-  .calendar-card {
-    // Extend Foundry's ui-control base styling
-    padding: 1.25rem;
-    border-radius: 6px;
-    min-height: 220px;
-    cursor: var(--cursor-pointer, pointer);
-    width: 100%; // Ensure cards use full available width
-    position: relative;
+    grid-template-columns: 380px 1fr;
+    gap: 1px;
+    height: 100%;
     overflow: hidden;
-    
-    // Use Foundry's interactive colors with enhanced gradients
-    border: 1px solid var(--color-border-light-tertiary);
-    background: linear-gradient(145deg, var(--color-bg-option), var(--color-bg-alt));
-    transition: all 0.3s ease;
-    
-    // Add subtle inner shadow for depth
-    box-shadow: 
-      inset 0 1px 0 rgba(255, 255, 255, 0.1),
-      0 2px 4px rgba(0, 0, 0, 0.1);
-
-    // Enhanced Foundry hover effect
-    &:hover {
-      text-shadow: 0 0 8px var(--color-shadow-primary);
-      border-color: var(--color-warm-2);
-      background: linear-gradient(145deg, var(--color-bg-primary), var(--color-bg-option));
-      box-shadow: 
-        inset 0 1px 0 rgba(255, 255, 255, 0.15),
-        0 4px 12px rgba(0, 0, 0, 0.15),
-        0 0 8px var(--color-shadow-primary);
-      transform: translateY(-2px);
-    }
-
-    // Enhanced active state
-    &.active {
-      background: linear-gradient(145deg, var(--color-bg-primary), var(--color-warm-5));
-      border-color: var(--color-warm-2);
-      box-shadow: 
-        inset 0 1px 0 rgba(255, 255, 255, 0.2),
-        0 0 12px var(--color-warm-1);
-      
-      &::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 3px;
-        background: linear-gradient(90deg, var(--color-warm-1), var(--color-warm-2), var(--color-warm-1));
-        z-index: 1;
-      }
-    }
-
-    // Enhanced picked/selected state
-    &.picked {
-      outline: 2px solid var(--color-warm-1);
-      outline-offset: -1px;
-      box-shadow: 
-        inset 0 1px 0 rgba(255, 255, 255, 0.2),
-        0 0 16px var(--color-warm-1),
-        inset 0 0 20px rgba(255, 200, 100, 0.1);
-      background: linear-gradient(145deg, var(--color-bg-primary), var(--color-warm-5));
-      border-color: var(--color-warm-1);
-      
-      &::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        right: 0;
-        width: 0;
-        height: 0;
-        border-top: 24px solid var(--color-warm-1);
-        border-left: 24px solid transparent;
-        z-index: 2;
-      }
-      
-      // Add checkmark in corner
-      &::before {
-        content: '✓';
-        position: absolute;
-        top: 4px;
-        right: 6px;
-        color: white;
-        font-size: 12px;
-        font-weight: bold;
-        z-index: 3;
-      }
-    }
-    
-    // Variant calendar cards have a subtle visual distinction
-    &.variant {
-      border-left: 3px solid var(--color-cool-2);
-      margin-left: 1rem;
-      
-      // No connecting line - just indentation and border
-      
-      &:hover {
-        border-left-color: var(--color-cool-1);
-      }
-      
-      &.picked {
-        border-left-color: var(--color-warm-1);
-      }
-      
-      .calendar-name .variant-indicator i {
-        transform: rotate(45deg);
-      }
-    }
-
-    // Hierarchical indentation for variants
-    &.hierarchy-level-1 {
-      margin-left: 1.5rem;
-      border-left: 2px solid var(--color-cool-3);
-      
-      // No connecting line - just indentation and border
-      
-      .calendar-name {
-        font-size: 1rem; // Slightly smaller for hierarchy
-        
-        .variant-indicator {
-          color: var(--color-cool-2);
-          opacity: 0.9;
-        }
-      }
-      
-      &:hover {
-        border-left-color: var(--color-cool-2);
-      }
-      
-      &.picked {
-        border-left-color: var(--color-warm-2);
-      }
-    }
-
-    .card-header {
-      margin-bottom: 0.5rem;
-      gap: 0.5rem;
-
-      .calendar-title-row {
-        align-items: flex-start;
-        gap: 0.5rem;
-
-        .calendar-title-info {
-          flex: 1;
-          min-width: 0;
-
-          .calendar-name {
-            margin: 0 0 0.25rem 0;
-            font-size: 1.1rem;
-            font-weight: 600;
-            color: var(--color-text-light-primary);
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            
-            .variant-indicator {
-              color: var(--color-cool-1);
-              font-size: 0.9rem;
-              opacity: 0.8;
-              
-              i {
-                transform: rotate(0deg);
-                transition: transform 0.2s ease;
-              }
-            }
-          }
-
-          .calendar-setting {
-            font-size: 0.8rem;
-            color: var(--color-text-light-7);
-            font-style: italic;
-          }
-          
-          .variant-info {
-            font-size: 0.75rem;
-            color: var(--color-cool-2);
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            background: var(--color-bg-secondary);
-            padding: 0.125rem 0.375rem;
-            border-radius: 3px;
-            border: 1px solid var(--color-cool-5);
-            margin-top: 0.25rem;
-            display: inline-block;
-          }
-        }
-
-        .calendar-badges {
-          flex-shrink: 0;
-          align-items: center;
-          gap: 0.375rem;
-
-          .current-badge {
-            color: var(--color-warm-1);
-            font-size: 1.2rem;
-            filter: drop-shadow(0 0 4px var(--color-warm-1));
-            animation: current-star-glow 3s ease-in-out infinite alternate;
-            
-            i {
-              transform-origin: center;
-            }
-          }
-
-          .module-badge {
-            padding: 0.25rem 0.5rem;
-            border-radius: 12px;
-            font-size: 0.7rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-            pointer-events: none; // Make it non-interactive
-            
-            // Default (dark theme) styling
-            background: linear-gradient(135deg, var(--color-cool-2), var(--color-cool-1));
-            color: var(--color-text-light-primary);
-            border: 1px solid var(--color-cool-3);
-            
-            i {
-              margin-right: 0.25rem;
-              font-size: 0.8rem;
-            }
-            
-            // Add "MODULE" text after icon for clarity
-            &::after {
-              content: 'MODULE';
-            }
-          }
-
-          .external-badge {
-            padding: 0.25rem 0.5rem;
-            border-radius: 12px;
-            font-size: 0.7rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-            pointer-events: none; // Make it non-interactive
-            
-            // Default (dark theme) styling
-            background: linear-gradient(135deg, var(--color-border-light-secondary), var(--color-border-light-tertiary));
-            color: var(--color-text-light-primary);
-            border: 1px solid var(--color-border-light-primary);
-            
-            i {
-              margin-right: 0.25rem;
-              font-size: 0.8rem;
-            }
-            
-            // Add "EXTERNAL" text after icon for clarity
-            &::after {
-              content: 'EXTERNAL';
-            }
-          }
-        }
-      }
-      
-      .source-info {
-        align-items: center;
-        gap: 0.625rem;
-        width: 100%; // Take full width now that it's on its own row
-        background: rgba(0, 0, 0, 0.1);
-        padding: 0.5rem 0.75rem;
-        border-radius: 4px;
-        margin-top: 0.5rem;
-        border: 1px solid rgba(255, 255, 255, 0.05);
-        
-        .source-icon {
-          font-size: 0.9rem;
-          color: var(--color-text-light-5);
-          flex-shrink: 0;
-          width: 1.1rem;
-          text-align: center;
-        }
-        
-        .source-label {
-          font-size: 0.85rem;
-          color: var(--color-text-light-5);
-          font-weight: 600;
-          word-break: break-word;
-          line-height: 1.3;
-          flex: 1;
-          text-transform: uppercase;
-          letter-spacing: 0.3px;
-        }
-      }
-    }
-
-    .card-content {
-      flex: 1;
-      gap: 0.75rem;
-
-      .calendar-description {
-        font-size: 0.9rem;
-        line-height: 1.4;
-        margin: 0;
-        color: var(--color-text-light-6);
-      }
-
-      .preview-section {
-        margin-top: auto;
-        
-        .sample-preview, 
-        .mini-preview {
-          background: linear-gradient(145deg, var(--color-bg-secondary), var(--color-bg-alt));
-          border: 1px solid var(--color-border-light-tertiary);
-          border-radius: 5px;
-          padding: 0.75rem;
-          margin-bottom: 0.75rem;
-          box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-          transition: all 0.2s ease;
-          
-          &:hover {
-            background: linear-gradient(145deg, var(--color-bg-alt), var(--color-bg-secondary));
-            border-color: var(--color-border-light-secondary);
-            box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.15);
-          }
-
-          label {
-            font-size: 0.7rem;
-            font-weight: 700;
-            color: var(--color-text-light-6);
-            text-transform: uppercase;
-            letter-spacing: 0.8px;
-            margin-bottom: 0.375rem;
-            display: flex;
-            align-items: center;
-            gap: 0.25rem;
-            
-            &::before {
-              content: '◆';
-              font-size: 0.6rem;
-              color: var(--color-cool-2);
-            }
-          }
-
-          .sample-date,
-          .mini-format {
-            font-family: var(--font-mono);
-            font-size: 0.9rem;
-            color: var(--color-text-light-primary);
-            font-weight: 600;
-            line-height: 1.3;
-            background: rgba(0, 0, 0, 0.1);
-            padding: 0.25rem 0.5rem;
-            border-radius: 3px;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-          }
-        }
-        
-        .mini-preview {
-          background: linear-gradient(145deg, var(--color-warm-5), var(--color-warm-4));
-          border-color: var(--color-warm-3);
-          
-          &:hover {
-            background: linear-gradient(145deg, var(--color-warm-4), var(--color-warm-3));
-            border-color: var(--color-warm-2);
-          }
-          
-          label {
-            color: var(--color-warm-1);
-            
-            &::before {
-              color: var(--color-warm-2);
-              content: '★';
-            }
-          }
-          
-          .mini-format {
-            color: var(--color-warm-1);
-            font-weight: 700;
-            background: rgba(255, 200, 100, 0.1);
-            border-color: var(--color-warm-3);
-          }
-        }
-      }
-    }
-
-    .card-actions {
-      margin-top: 0.75rem;
-      align-items: center;
-      gap: 0.5rem;
-
-      // Use native Foundry button styling
-      button.button {
-        flex: 1;
-        padding: 0.375rem 0.75rem;
-        font-size: 0.8rem;
-        
-        i {
-          margin-right: 0.25rem;
-        }
-      }
-
-      .selected-indicator {
-        color: var(--color-warm-1);
-        font-size: 1.1rem;
-        animation: foundry-pulse 2s infinite;
-      }
-    }
+    background: var(--color-border-dark);
   }
 
-  // No calendars state
-  .no-calendars {
-    padding: 3rem;
-    text-align: center;
-    color: var(--color-text-light-7);
-    min-height: 200px;
-    justify-content: center;
+  // Left Panel: Calendar List (Master)
+  .calendar-list-panel {
+    display: flex;
+    flex-direction: column;
+    background: var(--color-bg);
+    overflow: hidden;
 
-    .no-calendars-icon {
-      font-size: 3rem;
-      margin-bottom: 1rem;
-      opacity: 0.5;
-      color: var(--color-text-light-7);
-    }
+    .panel-header {
+      padding: 12px;
+      background: var(--color-bg-btn);
+      border-bottom: 1px solid var(--color-border-dark);
+      flex-shrink: 0;
 
-    .no-calendars-message {
-      h4 {
-        margin: 0 0 0.5rem 0;
-        color: var(--color-text-light-primary);
-        font-weight: 600;
-      }
-
-      p {
-        margin: 0;
-        font-size: 0.9rem;
-        max-width: 300px;
-      }
-    }
-  }
-}
-
-// Calendar Preview Dialog Styles
-.seasons-stars.calendar-preview-dialog {
-  .calendar-preview {
-    padding: 1rem;
-    max-width: none;
-    
-    .preview-header {
-      margin-bottom: 1.5rem;
-      padding-bottom: 1rem;
-      border-bottom: 1px solid var(--color-border-light-secondary);
-      
       h3 {
-        margin: 0 0 0.5rem 0;
-        font-size: 1.4rem;
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+        color: var(--color-text-light-primary);
+      }
+    }
+
+    .calendar-list-container {
+      flex: 1;
+      overflow-y: auto;
+      overflow-x: hidden;
+
+      &::-webkit-scrollbar {
+        width: 8px;
+      }
+
+      &::-webkit-scrollbar-track {
+        background: var(--color-bg-alt);
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background: var(--color-border-light-tertiary);
+        border-radius: 4px;
+
+        &:hover {
+          background: var(--color-border-light-secondary);
+        }
+      }
+    }
+  }
+
+  // Module Groups (Collapsible)
+  .module-group {
+    border-bottom: 1px solid var(--color-border-dark);
+
+    .module-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px;
+      background: var(--color-bg-alt);
+      cursor: pointer;
+      transition: background 0.2s ease;
+      user-select: none;
+
+      &:hover {
+        background: var(--color-bg-option);
+      }
+
+      .collapse-icon {
+        font-size: 10px;
+        color: var(--color-text-light-6);
+        transition: transform 0.2s ease;
+      }
+
+      .module-icon {
+        font-size: 14px;
+        color: var(--color-text-light-5);
+        width: 16px;
+        text-align: center;
+      }
+
+      .module-name {
+        flex: 1;
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--color-text-light-primary);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+
+      .calendar-count {
+        font-size: 11px;
+        color: var(--color-text-light-6);
+        background: var(--color-bg);
+        padding: 2px 8px;
+        border-radius: 10px;
+      }
+    }
+
+    &.collapsed {
+      .collapse-icon {
+        transform: rotate(-90deg);
+      }
+
+      .module-calendars {
+        display: none;
+      }
+    }
+
+    .module-calendars {
+      background: var(--color-bg);
+    }
+  }
+
+  // Calendar List Items
+  .calendar-list-item {
+    display: flex;
+    align-items: center;
+    padding: 10px 12px 10px 36px;
+    border-bottom: 1px solid var(--color-border-dark-tertiary);
+    cursor: pointer;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background: var(--color-bg-option);
+    }
+
+    &.selected {
+      background: linear-gradient(90deg, var(--color-warm-5), var(--color-bg-option));
+      border-left: 3px solid var(--color-warm-2);
+      padding-left: 33px;
+    }
+
+    &.current {
+      .current-icon {
+        color: var(--color-warm-1);
+        margin-right: 6px;
+        font-size: 12px;
+      }
+    }
+
+    .calendar-list-main {
+      flex: 1;
+      min-width: 0;
+
+      .calendar-list-title {
+        font-size: 13px;
+        font-weight: 500;
+        color: var(--color-text-light-primary);
+        display: flex;
+        align-items: center;
+        margin-bottom: 4px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .calendar-list-tags {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+        margin-top: 4px;
+      }
+    }
+  }
+
+  // Tags
+  .tag {
+    display: inline-block;
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: var(--color-cool-5);
+    color: var(--color-cool-1);
+    text-transform: lowercase;
+    font-weight: 500;
+    border: 1px solid var(--color-cool-4);
+  }
+
+  // Right Panel: Calendar Details
+  .calendar-detail-panel {
+    display: flex;
+    flex-direction: column;
+    background: var(--color-bg);
+    overflow: hidden;
+
+    .detail-content {
+      flex: 1;
+      overflow-y: auto;
+      overflow-x: hidden;
+      padding: 20px;
+
+      &::-webkit-scrollbar {
+        width: 8px;
+      }
+
+      &::-webkit-scrollbar-track {
+        background: var(--color-bg-alt);
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background: var(--color-border-light-tertiary);
+        border-radius: 4px;
+
+        &:hover {
+          background: var(--color-border-light-secondary);
+        }
+      }
+    }
+
+    .detail-header {
+      margin-bottom: 24px;
+      padding-bottom: 16px;
+      border-bottom: 2px solid var(--color-border-dark);
+
+      .detail-title {
+        margin: 0 0 8px 0;
+        font-size: 24px;
         font-weight: 600;
         color: var(--color-text-light-primary);
         line-height: 1.2;
       }
-      
-      .preview-setting {
-        font-size: 0.9rem;
-        color: var(--color-text-light-secondary);
+
+      .detail-setting {
+        margin: 0;
+        font-size: 14px;
+        color: var(--color-text-light-6);
         font-style: italic;
-        margin-top: 0.25rem;
       }
     }
-    
-    .preview-description {
-      margin-bottom: 1.5rem;
-      padding: 1rem;
-      background: var(--color-bg-secondary);
-      border: 1px solid var(--color-border-light-secondary);
-      border-radius: 4px;
-      font-size: 0.95rem;
-      line-height: 1.5;
-      color: var(--color-text-light-primary);
-    }
-    
-    .preview-samples {
-      margin-bottom: 1.5rem;
-      
+
+    .detail-section {
+      margin-bottom: 20px;
+
       h4 {
-        margin: 0 0 0.75rem 0;
-        font-size: 1.1rem;
-        font-weight: 600;
-        color: var(--color-text-light-primary);
-        display: flex;
-        align-items: center;
-        
-        &::before {
-          content: "📅";
-          margin-right: 0.5rem;
-          font-size: 1rem;
-        }
+        margin: 0 0 10px 0;
+        font-size: 13px;
+        font-weight: 700;
+        color: var(--color-text-light-5);
+        text-transform: uppercase;
+        letter-spacing: 0.8px;
       }
-      
-      .sample-date {
-        background: var(--color-bg-option);
-        border: 1px solid var(--color-border-light-secondary);
-        border-radius: 3px;
-        padding: 0.5rem 0.75rem;
-        margin-bottom: 0.5rem;
-        font-family: var(--font-mono);
-        font-size: 0.9rem;
+
+      p {
+        margin: 0;
+        font-size: 14px;
+        line-height: 1.6;
         color: var(--color-text-light-primary);
-        font-weight: 500;
-        
+      }
+    }
+
+    .format-preview {
+      .format-item {
+        background: var(--color-bg-alt);
+        border: 1px solid var(--color-border-dark);
+        border-radius: 4px;
+        padding: 12px;
+        margin-bottom: 10px;
+
         &:last-child {
           margin-bottom: 0;
         }
+
+        label {
+          display: block;
+          font-size: 11px;
+          font-weight: 600;
+          color: var(--color-text-light-6);
+          text-transform: uppercase;
+          letter-spacing: 0.5px;
+          margin-bottom: 6px;
+        }
+
+        .format-sample {
+          font-family: var(--font-mono);
+          font-size: 14px;
+          color: var(--color-text-light-primary);
+          font-weight: 500;
+
+          &.mini {
+            color: var(--color-warm-1);
+            font-weight: 600;
+          }
+        }
       }
     }
-    
-    .preview-structure {
-      h4 {
-        margin: 0 0 0.75rem 0;
-        font-size: 1.1rem;
-        font-weight: 600;
-        color: var(--color-text-light-primary);
+
+    .source-details {
+      .source-item {
         display: flex;
         align-items: center;
-        
-        &::before {
-          content: "📊";
-          margin-right: 0.5rem;
-          font-size: 1rem;
-        }
-      }
-      
-      .structure-info {
-        background: var(--color-bg-secondary);
-        border: 1px solid var(--color-border-light-secondary);
+        gap: 10px;
+        padding: 10px;
+        background: var(--color-bg-alt);
+        border: 1px solid var(--color-border-dark);
         border-radius: 4px;
-        padding: 1rem;
-        
-        div {
-          margin-bottom: 0.5rem;
-          font-size: 0.9rem;
+
+        .source-icon {
+          font-size: 16px;
+          color: var(--color-text-light-5);
+          width: 20px;
+          text-align: center;
+        }
+
+        span {
+          font-size: 13px;
           color: var(--color-text-light-primary);
-          
-          &:last-child {
-            margin-bottom: 0;
+          font-weight: 500;
+        }
+      }
+    }
+
+    .references-list {
+      .reference-item {
+        display: flex;
+        align-items: flex-start;
+        gap: 10px;
+        padding: 10px;
+        background: var(--color-bg-alt);
+        border: 1px solid var(--color-border-dark);
+        border-radius: 4px;
+        margin-bottom: 8px;
+
+        &:last-child {
+          margin-bottom: 0;
+        }
+
+        i {
+          font-size: 14px;
+          color: var(--color-text-light-5);
+          margin-top: 2px;
+          flex-shrink: 0;
+        }
+
+        a {
+          flex: 1;
+          font-size: 13px;
+          color: var(--color-text-hyperlink);
+          word-break: break-all;
+          text-decoration: none;
+
+          &:hover {
+            text-decoration: underline;
           }
-          
-          strong {
+        }
+
+        &.citation {
+          flex-direction: column;
+
+          .citation-text {
+            font-size: 13px;
             color: var(--color-text-light-primary);
-            font-weight: 600;
-            margin-right: 0.25rem;
+            line-height: 1.5;
           }
+
+          .citation-notes {
+            font-size: 12px;
+            color: var(--color-text-light-6);
+            font-style: italic;
+            margin-top: 4px;
+          }
+        }
+      }
+    }
+
+    .tags-display {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .detail-placeholder {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 40px;
+      text-align: center;
+      color: var(--color-text-light-7);
+
+      .placeholder-icon {
+        font-size: 48px;
+        margin-bottom: 16px;
+        opacity: 0.3;
+      }
+
+      p {
+        margin: 0;
+        font-size: 14px;
+      }
+    }
+
+    .file-picker-detail {
+      .file-path-display {
+        font-family: var(--font-mono);
+        font-size: 13px;
+        padding: 10px;
+        background: var(--color-bg-alt);
+        border: 1px solid var(--color-border-dark);
+        border-radius: 4px;
+        word-break: break-all;
+      }
+
+      .no-file-message {
+        font-size: 14px;
+        color: var(--color-text-light-6);
+        font-style: italic;
+      }
+
+      .file-actions {
+        margin-top: 16px;
+
+        button {
+          font-size: 13px;
+          padding: 8px 16px;
+
+          i {
+            margin-right: 6px;
+          }
+        }
+      }
+    }
+  }
+
+  // File picker group specific styling
+  .file-picker-group {
+    .module-header {
+      background: var(--color-warm-5);
+
+      &:hover {
+        background: var(--color-warm-4);
+      }
+
+      .module-icon {
+        color: var(--color-warm-1);
+      }
+    }
+  }
+
+  // Dialog footer buttons (from old implementation)
+  .dialog-buttons {
+    padding: 12px;
+    gap: 10px;
+    justify-content: flex-end;
+    display: flex;
+    background: var(--color-bg-btn);
+    border-top: 1px solid var(--color-border-dark);
+
+    button {
+      padding: 8px 16px;
+      font-size: 13px;
+
+      i {
+        margin-right: 6px;
+      }
+
+      &.ss-button.primary {
+        background: var(--color-warm-2) !important;
+        color: white !important;
+        border-color: var(--color-warm-2) !important;
+        font-weight: 600;
+
+        &:hover {
+          background: var(--color-warm-1) !important;
+          border-color: var(--color-warm-1) !important;
+        }
+
+        &:disabled {
+          opacity: 0.6;
+          background: var(--color-bg-alt) !important;
+          color: var(--color-text-light-secondary) !important;
+          border-color: var(--color-border-light-secondary) !important;
         }
       }
     }
   }
 }
 
-// Dialog footer buttons
-.dialog-buttons {
-  padding: 1rem;
-  gap: 0.75rem;
-  justify-content: flex-end;
-  margin-top: auto;
-  
-  button {
-    padding: 0.5rem 1rem;
-    font-size: 0.9rem;
-    
-    i {
-      margin-right: 0.5rem;
-    }
-    
-    &.ss-button.primary {
-      background: var(--color-warm-2) !important;
-      color: white !important;
-      border-color: var(--color-warm-2) !important;
-      font-weight: 600;
-      
-      &:hover {
-        background: var(--color-warm-1) !important;
-        border-color: var(--color-warm-1) !important;
-        color: white !important;
-      }
-      
-      &:disabled {
-        opacity: 0.6;
-        background: var(--color-bg-alt) !important;
-        color: var(--color-text-light-secondary) !important;
-        border-color: var(--color-border-light-secondary) !important;
-      }
-    }
-  }
-}
-
-// Native Foundry pulse animation
-@keyframes foundry-pulse {
-  0%, 100% { 
-    opacity: 1; 
-    transform: scale(1);
-  }
-  50% { 
-    opacity: 0.7; 
-    transform: scale(1.05);
-  }
-}
-
-// Current star glow animation
-@keyframes current-star-glow {
-  0% {
-    filter: drop-shadow(0 0 4px var(--color-warm-1));
-    transform: scale(1);
-  }
-  50% {
-    filter: drop-shadow(0 0 8px var(--color-warm-1)) drop-shadow(0 0 16px var(--color-warm-2));
-    transform: scale(1.1);
-  }
-  100% {
-    filter: drop-shadow(0 0 4px var(--color-warm-1));
-    transform: scale(1);
-  }
-}
-
-// Light theme overrides
-body.theme-light {
+// Responsive design
+@media (max-width: 900px) {
   .seasons-stars.calendar-selection-dialog {
-    .calendar-badges {
-      .module-badge {
-        background: linear-gradient(135deg, var(--color-cool-4), var(--color-cool-3));
-        color: var(--color-text-dark-primary);
-        border: 1px solid var(--color-cool-2);
-      }
-      
-      .external-badge {
-        background: linear-gradient(135deg, var(--color-border-light-secondary), var(--color-border-light-tertiary));
-        color: var(--color-text-dark-primary);
-        border: 1px solid var(--color-border-light-primary);
-      }
+    .calendar-selection-layout {
+      grid-template-columns: 1fr;
+      grid-template-rows: 300px 1fr;
+    }
+
+    .calendar-list-panel {
+      border-bottom: 1px solid var(--color-border-dark);
+    }
+  }
+}
+
+// Dark theme adjustments
+body.theme-dark {
+  .seasons-stars.calendar-selection-dialog {
+    .module-header {
+      background: var(--color-bg-darker);
     }
   }
 }

--- a/packages/core/templates/calendar-selection-dialog.hbs
+++ b/packages/core/templates/calendar-selection-dialog.hbs
@@ -1,174 +1,202 @@
 <div class="dialog-content">
-  <form class="standard-form">
-    <div class="form-group">
-      <label>{{localize "SEASONS_STARS.dialog.calendar_selection.choose_calendar"}}</label>
-      <p class="hint">{{localize "SEASONS_STARS.dialog.calendar_selection.choose_hint"}}</p>
-      
-      <div class="form-fields">
-        <div class="calendar-selection-grid">
-          {{#each calendars}}
-          <div class="calendar-card ui-control {{#if isCurrent}}active{{/if}} {{#if isSelected}}picked{{/if}} {{#if isVariant}}variant{{/if}} {{#if hierarchyLevel}}hierarchy-level-{{hierarchyLevel}}{{/if}} source-{{sourceType}}" 
-               data-action="selectCalendar"
-               data-calendar-id="{{id}}" 
-               title="{{description}}">
-            
-            <div class="card-header flexcol">
-              <div class="calendar-title-row flexrow">
-                <div class="calendar-title-info flexcol">
-                  <h4 class="calendar-name">
-                    {{#if isVariant}}
-                    <span class="variant-indicator">
-                      <i class="fas fa-code-branch"></i>
-                    </span>
+  <div class="calendar-selection-layout">
+    <!-- Left Panel: Calendar List (Master) -->
+    <div class="calendar-list-panel">
+      <div class="panel-header">
+        <h3>{{localize "SEASONS_STARS.dialog.calendar_selection.available_calendars"}}</h3>
+      </div>
+
+      <div class="calendar-list-container">
+        {{#if calendarsByModule}}
+          {{#each calendarsByModule}}
+          <div class="module-group {{#if collapsed}}collapsed{{/if}}" data-module-id="{{moduleId}}">
+            <div class="module-header" data-action="toggleModule" data-module-id="{{moduleId}}">
+              <i class="fas fa-chevron-down collapse-icon"></i>
+              <i class="{{moduleIcon}} module-icon"></i>
+              <span class="module-name">{{moduleName}}</span>
+              <span class="calendar-count">{{calendarCount}}</span>
+            </div>
+
+            <div class="module-calendars">
+              {{#each calendars}}
+              <div class="calendar-list-item {{#if isCurrent}}current{{/if}} {{#if isSelected}}selected{{/if}}"
+                   data-action="selectCalendar"
+                   data-calendar-id="{{id}}">
+                <div class="calendar-list-main">
+                  <div class="calendar-list-title">
+                    {{#if isCurrent}}
+                    <i class="fas fa-star current-icon"></i>
                     {{/if}}
                     {{label}}
-                  </h4>
-                  {{#if setting}}
-                  <span class="calendar-setting">{{setting}}</span>
-                  {{/if}}
-                  {{#if variantInfo}}
-                  <span class="variant-info">{{variantInfo}}</span>
-                  {{/if}}
-                </div>
-                <div class="calendar-badges flexrow">
-                  {{#if isCurrent}}
-                  <div class="current-badge" data-tooltip="Current active calendar">
-                    <i class="fas fa-star"></i>
                   </div>
-                  {{/if}}
-                  {{#if isModuleSource}}
-                  <div class="module-badge" data-tooltip="{{sourceDescription}}">
-                    <i class="fas fa-puzzle-piece"></i>
-                  </div>
-                  {{else if isExternalSource}}
-                  <div class="external-badge" data-tooltip="{{sourceDescription}}">
-                    <i class="fas fa-cloud"></i>
+                  {{#if tags}}
+                  <div class="calendar-list-tags">
+                    {{#each tags}}
+                    <span class="tag">{{this}}</span>
+                    {{/each}}
                   </div>
                   {{/if}}
                 </div>
               </div>
-              <div class="source-info flexrow">
-                <i class="{{sourceIcon}} source-icon"></i>
-                <span class="source-label">{{sourceLabel}}</span>
-              </div>
-            </div>
-
-            <div class="card-content flexcol">
-              <p class="calendar-description">{{description}}</p>
-              
-              <div class="preview-section">
-                <div class="sample-preview">
-                  <label>{{localize "SEASONS_STARS.dialog.calendar_selection.sample"}}:</label>
-                  <span class="sample-date">{{sampleDate}}</span>
-                </div>
-                
-                <div class="mini-preview">
-                  <label>Mini Widget:</label>
-                  <span class="mini-format">{{miniPreview}}</span>
-                </div>
-              </div>
-            </div>
-
-            <div class="card-actions flexrow">
-              <button type="button" data-action="previewCalendar" class="button" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.preview_tooltip'}}">
-                <i class="fas fa-eye"></i>
-                {{localize "SEASONS_STARS.dialog.calendar_selection.preview"}}
-              </button>
-              {{#if isSelected}}
-              <i class="fas fa-check-circle selected-indicator"></i>
-              {{/if}}
+              {{/each}}
             </div>
           </div>
           {{/each}}
-          
-          <!-- File Picker Card -->
-          <div class="calendar-card ui-control file-picker-card {{#if filePickerActive}}active{{/if}} {{#if filePickerSelected}}picked{{/if}}" 
-               {{#if selectedFilePath}}data-action="selectCalendar" data-calendar-id="__FILE_PICKER__"{{else}}data-action="openFilePicker"{{/if}}
-               title="{{localize 'SEASONS_STARS.dialog.calendar_selection.custom_file_hint'}}">
-            
-            <div class="card-header flexcol">
-              <div class="calendar-title-row flexrow">
-                <div class="calendar-title-info flexcol">
-                  <h4 class="calendar-name">
-                    <span class="file-picker-indicator">
-                      <i class="fas fa-folder-open"></i>
-                    </span>
-                    {{localize "SEASONS_STARS.dialog.calendar_selection.custom_file"}}
-                  </h4>
-                  {{#if selectedFilePath}}
-                  <span class="calendar-setting">{{selectedFilePath}}</span>
-                  {{/if}}
-                </div>
-                <div class="calendar-badges flexrow">
+        {{/if}}
+
+        {{#if showFilePicker}}
+        <div class="module-group file-picker-group">
+          <div class="module-header">
+            <i class="fas fa-folder-open module-icon"></i>
+            <span class="module-name">{{localize "SEASONS_STARS.dialog.calendar_selection.custom_file"}}</span>
+          </div>
+
+          <div class="module-calendars">
+            <div class="calendar-list-item {{#if filePickerActive}}current{{/if}} {{#if filePickerSelected}}selected{{/if}}"
+                 {{#if selectedFilePath}}data-action="selectCalendar" data-calendar-id="__FILE_PICKER__"{{else}}data-action="openFilePicker"{{/if}}>
+              <div class="calendar-list-main">
+                <div class="calendar-list-title">
                   {{#if filePickerActive}}
-                  <div class="current-badge" data-tooltip="Current active calendar">
-                    <i class="fas fa-star"></i>
-                  </div>
+                  <i class="fas fa-star current-icon"></i>
                   {{/if}}
-                  <div class="file-badge" data-tooltip="Custom calendar file">
-                    <i class="fas fa-file-alt"></i>
-                  </div>
+                  {{#if selectedFilePath}}
+                  {{selectedFileName}}
+                  {{else}}
+                  {{localize "SEASONS_STARS.dialog.calendar_selection.browse_for_file"}}
+                  {{/if}}
                 </div>
-              </div>
-              <div class="source-info flexrow">
-                <i class="fas fa-folder-open source-icon"></i>
-                <span class="source-label">Custom File</span>
-              </div>
-            </div>
-
-            <div class="card-content flexcol">
-              <p class="calendar-description">
                 {{#if selectedFilePath}}
-                  {{localize "SEASONS_STARS.dialog.calendar_selection.file_loaded"}}
-                {{else}}
-                  {{localize "SEASONS_STARS.dialog.calendar_selection.custom_file_hint"}}
-                {{/if}}
-              </p>
-              
-              <div class="preview-section">
-                {{#if selectedFilePath}}
-                <div class="sample-preview">
-                  <label>{{localize "SEASONS_STARS.dialog.calendar_selection.file_path"}}:</label>
-                  <span class="sample-date file-path">{{selectedFilePath}}</span>
-                </div>
-                {{else}}
-                <div class="sample-preview">
-                  <label>{{localize "SEASONS_STARS.dialog.calendar_selection.status"}}:</label>
-                  <span class="sample-date">{{localize "SEASONS_STARS.dialog.calendar_selection.click_to_select"}}</span>
+                <div class="calendar-list-tags">
+                  <span class="tag">custom</span>
                 </div>
                 {{/if}}
               </div>
-            </div>
-
-            <div class="card-actions flexrow">
-              {{#if selectedFilePath}}
-              <button type="button" data-action="clearFilePicker" class="button" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.clear_file'}}">
-                <i class="fas fa-times"></i>
-                {{localize "SEASONS_STARS.dialog.calendar_selection.clear"}}
-              </button>
-              {{else}}
-              <button type="button" data-action="openFilePicker" class="button" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.browse_tooltip'}}">
-                <i class="fas fa-folder-open"></i>
-                {{localize "SEASONS_STARS.dialog.calendar_selection.browse"}}
-              </button>
-              {{/if}}
-              {{#if filePickerActive}}
-              <i class="fas fa-check-circle selected-indicator"></i>
-              {{/if}}
             </div>
           </div>
         </div>
+        {{/if}}
       </div>
     </div>
-  </form>
 
-  {{#unless calendars.length}}
-  <div class="no-calendars flexcol">
-    <i class="fas fa-calendar-times no-calendars-icon"></i>
-    <div class="no-calendars-message">
-      <h4>{{localize "SEASONS_STARS.dialog.calendar_selection.no_calendars"}}</h4>
-      <p>{{localize "SEASONS_STARS.dialog.calendar_selection.no_calendars_hint"}}</p>
+    <!-- Right Panel: Calendar Details -->
+    <div class="calendar-detail-panel">
+      {{#if selectedCalendarData}}
+      <div class="detail-content">
+        <div class="detail-header">
+          <h2 class="detail-title">{{selectedCalendarData.label}}</h2>
+          {{#if selectedCalendarData.setting}}
+          <p class="detail-setting">{{selectedCalendarData.setting}}</p>
+          {{/if}}
+        </div>
+
+        {{#if selectedCalendarData.description}}
+        <div class="detail-section">
+          <h4>{{localize "SEASONS_STARS.dialog.calendar_selection.description"}}</h4>
+          <p>{{selectedCalendarData.description}}</p>
+        </div>
+        {{/if}}
+
+        <div class="detail-section">
+          <h4>{{localize "SEASONS_STARS.dialog.calendar_selection.date_formats"}}</h4>
+          <div class="format-preview">
+            <div class="format-item">
+              <label>{{localize "SEASONS_STARS.dialog.calendar_selection.full_widget"}}:</label>
+              <span class="format-sample">{{selectedCalendarData.sampleDate}}</span>
+            </div>
+            <div class="format-item">
+              <label>{{localize "SEASONS_STARS.dialog.calendar_selection.mini_widget"}}:</label>
+              <span class="format-sample mini">{{selectedCalendarData.miniPreview}}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="detail-section">
+          <h4>{{localize "SEASONS_STARS.dialog.calendar_selection.source_info"}}</h4>
+          <div class="source-details">
+            <div class="source-item">
+              <i class="{{selectedCalendarData.sourceIcon}} source-icon"></i>
+              <span>{{selectedCalendarData.sourceLabel}}</span>
+            </div>
+          </div>
+        </div>
+
+        {{#if selectedCalendarData.calendarSources}}
+        <div class="detail-section">
+          <h4>{{localize "SEASONS_STARS.dialog.calendar_selection.references"}}</h4>
+          <div class="references-list">
+            {{#each selectedCalendarData.calendarSources}}
+            {{#if isUrl}}
+            <div class="reference-item">
+              <i class="fas fa-link"></i>
+              <a href="{{url}}" target="_blank" rel="noopener noreferrer">{{url}}</a>
+            </div>
+            {{else}}
+            <div class="reference-item citation">
+              <i class="fas fa-book"></i>
+              <span class="citation-text">{{citation}}</span>
+              {{#if notes}}
+              <span class="citation-notes">{{notes}}</span>
+              {{/if}}
+            </div>
+            {{/if}}
+            {{/each}}
+          </div>
+        </div>
+        {{/if}}
+
+        {{#if selectedCalendarData.author}}
+        <div class="detail-section">
+          <h4>{{localize "SEASONS_STARS.dialog.calendar_selection.author"}}</h4>
+          <p>{{selectedCalendarData.author}}</p>
+        </div>
+        {{/if}}
+
+        {{#if selectedCalendarData.tags}}
+        <div class="detail-section">
+          <h4>{{localize "SEASONS_STARS.dialog.calendar_selection.tags"}}</h4>
+          <div class="tags-display">
+            {{#each selectedCalendarData.tags}}
+            <span class="tag">{{this}}</span>
+            {{/each}}
+          </div>
+        </div>
+        {{/if}}
+      </div>
+      {{else if filePickerSelected}}
+      <div class="detail-content file-picker-detail">
+        <div class="detail-header">
+          <h2 class="detail-title">{{localize "SEASONS_STARS.dialog.calendar_selection.custom_file"}}</h2>
+        </div>
+
+        <div class="detail-section">
+          {{#if selectedFilePath}}
+          <h4>{{localize "SEASONS_STARS.dialog.calendar_selection.file_path"}}</h4>
+          <p class="file-path-display">{{selectedFilePath}}</p>
+
+          <div class="file-actions">
+            <button type="button" data-action="clearFilePicker" class="button">
+              <i class="fas fa-times"></i>
+              {{localize "SEASONS_STARS.dialog.calendar_selection.clear_file"}}
+            </button>
+          </div>
+          {{else}}
+          <p class="no-file-message">{{localize "SEASONS_STARS.dialog.calendar_selection.no_file_selected"}}</p>
+
+          <div class="file-actions">
+            <button type="button" data-action="openFilePicker" class="button">
+              <i class="fas fa-folder-open"></i>
+              {{localize "SEASONS_STARS.dialog.calendar_selection.browse"}}
+            </button>
+          </div>
+          {{/if}}
+        </div>
+      </div>
+      {{else}}
+      <div class="detail-placeholder">
+        <i class="fas fa-calendar-alt placeholder-icon"></i>
+        <p>{{localize "SEASONS_STARS.dialog.calendar_selection.select_to_view"}}</p>
+      </div>
+      {{/if}}
     </div>
   </div>
-  {{/unless}}
 </div>


### PR DESCRIPTION
Completely redesigned the calendar selection dialog to match the modern aesthetics of the custom calendar builder with a two-column master-detail interface.

## Changes

**Left Panel (Master)**:
- Table-like calendar list grouped by module/source
- Collapsible module sections with expand/collapse functionality
- Each module header shows icon, name, and calendar count
- Calendar items display name, current indicator (star), and tags
- Visual highlighting for currently selected calendar

**Right Panel (Detail)**:
- Calendar name and setting display
- Full description
- Sample date formats for both full and mini widgets
- Source module information with icons
- References section showing URLs and bibliographic citations
- Author information when available
- Tags display from calendar index and setting property

Closes #350

🤖 Generated with [Claude Code](https://claude.ai/code)