### PR TITLE
feat: migrate to Foundry native tooltips

### DIFF
--- a/docs/INTEGRATION-GUIDE.md
+++ b/docs/INTEGRATION-GUIDE.md
@@ -367,7 +367,7 @@ The corresponding Handlebars partial iterates the generated buttons:
         class='sidebar-button'
         data-action='clickSidebarButton'
         data-button-name='{{this.name}}'
-        title='{{this.tooltip}}'
+        data-tooltip='{{this.tooltip}}'
       >
         <i class='{{this.icon}}'></i>
         {{this.name}}

--- a/packages/core/templates/calendar-grid-widget.hbs
+++ b/packages/core/templates/calendar-grid-widget.hbs
@@ -10,28 +10,28 @@
     <div class="calendar-grid-header">
       <div class="navigation-controls">
         <div class="month-navigation">
-          <button type="button" class="nav-button" data-action="previousMonth" title="Previous Month">
+          <button type="button" class="nav-button" data-action="previousMonth" data-tooltip="Previous Month">
             <i class="fas fa-chevron-left"></i>
           </button>
           <div class="month-info">
             <div class="month-name">{{monthName}}</div>
             {{#if monthDescription}}
-              <div class="month-description" title="{{monthDescription}}">
+              <div class="month-description" data-tooltip="{{monthDescription}}">
                 <i class="fas fa-info-circle"></i>
               </div>
             {{/if}}
           </div>
-          <button type="button" class="nav-button" data-action="nextMonth" title="Next Month">
+          <button type="button" class="nav-button" data-action="nextMonth" data-tooltip="Next Month">
             <i class="fas fa-chevron-right"></i>
           </button>
         </div>
         
         <div class="year-navigation">
-          <button type="button" class="nav-button" data-action="previousYear" title="Previous Year">
+          <button type="button" class="nav-button" data-action="previousYear" data-tooltip="Previous Year">
             <i class="fas fa-angle-double-left"></i>
           </button>
-          <button type="button" class="year-display clickable" data-action="setYear" title="Click to set year">{{yearDisplay}}</button>
-          <button type="button" class="nav-button" data-action="nextYear" title="Next Year">
+          <button type="button" class="year-display clickable" data-action="setYear" data-tooltip="Click to set year">{{yearDisplay}}</button>
+          <button type="button" class="nav-button" data-action="nextYear" data-tooltip="Next Year">
             <i class="fas fa-angle-double-right"></i>
           </button>
         </div>
@@ -39,10 +39,10 @@
 
       <div class="header-actions">
         <div class="widget-switching-controls">
-          <button type="button" class="widget-switch-btn" data-action="switchToMain" title="Switch to Main Widget">
+          <button type="button" class="widget-switch-btn" data-action="switchToMain" data-tooltip="Switch to Main Widget">
             <i class="fas fa-expand-alt"></i>
           </button>
-          <button type="button" class="widget-switch-btn" data-action="switchToMini" title="Switch to Mini Widget">
+          <button type="button" class="widget-switch-btn" data-action="switchToMini" data-tooltip="Switch to Mini Widget">
             <i class="fas fa-compress-alt"></i>
           </button>
         </div>
@@ -52,7 +52,7 @@
               <button
                 type="button"
                 class="grid-sidebar-button"
-                title="{{this.tooltip}}"
+                data-tooltip="{{this.tooltip}}"
                 data-action="clickSidebarButton"
                 data-button-name="{{this.name}}"
               >
@@ -61,7 +61,7 @@
             {{/each}}
           </div>
         {{/if}}
-        <button type="button" class="today-button" data-action="goToToday" title="Go to current date">
+        <button type="button" class="today-button" data-action="goToToday" data-tooltip="Go to current date">
           <i class="fas fa-crosshairs"></i> Today
         </button>
       </div>
@@ -70,7 +70,7 @@
     {{!-- Weekday Headers --}}
     <div class="weekday-headers" style="--weekday-count: {{weekdays.length}};">
       {{#each weekdays}}
-        <div class="weekday-header" title="{{description}}">
+        <div class="weekday-header" data-tooltip="{{description}}">
           <span class="weekday-name">{{abbreviation}}</span>
         </div>
       {{/each}}
@@ -88,7 +88,7 @@
                      data-action="{{#if isClickable}}selectDate{{/if}}"
                      data-day="{{intercalaryName}}"
                      data-date="{{fullDate}}"
-                     title="{{#if isToday}}Current Date: {{/if}}{{intercalaryName}}{{#if intercalaryDescription}} - {{intercalaryDescription}}{{/if}}{{#if isClickable}} (Click to set date){{/if}}">
+                     data-tooltip="{{#if isToday}}Current Date: {{/if}}{{intercalaryName}}{{#if intercalaryDescription}} - {{intercalaryDescription}}{{/if}}{{#if isClickable}} (Click to set date){{/if}}">
                   <span class="intercalary-name">{{intercalaryName}}</span>
                   {{#if intercalaryDescription}}
                     <span class="intercalary-description">{{intercalaryDescription}}</span>
@@ -103,10 +103,10 @@
                      data-day="{{day}}"
                      data-date="{{fullDate}}"
                      data-category="{{primaryCategory}}"
-                     title="{{#if isToday}}Current Date: {{/if}}{{fullDate}}{{#if hasNotes}} - {{noteTooltip}}{{/if}}{{#if moonTooltip}} - {{moonTooltip}}{{/if}}{{#if isClickable}} (Click to set date){{/if}}">
+                     data-tooltip="{{#if isToday}}Current Date: {{/if}}{{fullDate}}{{#if hasNotes}} - {{noteTooltip}}{{/if}}{{#if moonTooltip}} - {{moonTooltip}}{{/if}}{{#if isClickable}} (Click to set date){{/if}}">
                   <span class="day-number">{{day}}</span>
                   {{#if primaryMoonPhase}}
-                    <div class="moon-indicator" {{#if primaryMoonColor}}style="color: {{primaryMoonColor}}"{{/if}} title="{{moonTooltip}}">
+                    <div class="moon-indicator" {{#if primaryMoonColor}}style="color: {{primaryMoonColor}}"{{/if}} data-tooltip="{{moonTooltip}}">
                       {{#if (eq primaryMoonPhase "new")}}<i class="fas fa-circle moon-phase-new"></i>{{/if}}
                       {{#if (eq primaryMoonPhase "waxing-crescent")}}<i class="fas fa-moon moon-phase-waxing-crescent"></i>{{/if}}
                       {{#if (eq primaryMoonPhase "first-quarter")}}<i class="fas fa-adjust moon-phase-first-quarter"></i>{{/if}}
@@ -136,10 +136,10 @@
                      data-day="{{day}}"
                      data-date="{{fullDate}}"
                      data-category="{{primaryCategory}}"
-                     title="{{#if isToday}}Current Date: {{/if}}{{fullDate}}{{#if hasNotes}} - {{noteTooltip}}{{/if}}{{#if moonTooltip}} - {{moonTooltip}}{{/if}}{{#if isClickable}} (Click to set date){{/if}}">
+                     data-tooltip="{{#if isToday}}Current Date: {{/if}}{{fullDate}}{{#if hasNotes}} - {{noteTooltip}}{{/if}}{{#if moonTooltip}} - {{moonTooltip}}{{/if}}{{#if isClickable}} (Click to set date){{/if}}">
                   <span class="day-number">{{day}}</span>
                   {{#if primaryMoonPhase}}
-                    <div class="moon-indicator" {{#if primaryMoonColor}}style="color: {{primaryMoonColor}}"{{/if}} title="{{moonTooltip}}">
+                    <div class="moon-indicator" {{#if primaryMoonColor}}style="color: {{primaryMoonColor}}"{{/if}} data-tooltip="{{moonTooltip}}">
                       {{#if (eq primaryMoonPhase "new")}}<i class="fas fa-circle moon-phase-new"></i>{{/if}}
                       {{#if (eq primaryMoonPhase "waxing-crescent")}}<i class="fas fa-moon moon-phase-waxing-crescent"></i>{{/if}}
                       {{#if (eq primaryMoonPhase "first-quarter")}}<i class="fas fa-adjust moon-phase-first-quarter"></i>{{/if}}
@@ -154,7 +154,7 @@
                     </div>
                   {{/if}}
                   {{#if hasNotes}}
-                    <button type="button" class="note-indicator" data-action="viewNotes" data-day="{{day}}" title="{{noteTooltip}} - Click to view/edit" data-note-count="{{noteCount}}">
+                    <button type="button" class="note-indicator" data-action="viewNotes" data-day="{{day}}" data-tooltip="{{noteTooltip}} - Click to view/edit" data-note-count="{{noteCount}}">
                       {{#if noteMultiple}}
                         <span class="note-count {{categoryClass}}">{{noteCount}}</span>
                       {{else}}
@@ -163,7 +163,7 @@
                     </button>
                   {{/if}}
                   {{#if canCreateNote}}
-                    <button type="button" class="quick-note-btn" data-action="createNote" data-day="{{day}}" title="Create note for this date">
+                    <button type="button" class="quick-note-btn" data-action="createNote" data-day="{{day}}" data-tooltip="Create note for this date">
                       <i class="fas fa-plus"></i>
                     </button>
                   {{/if}}

--- a/packages/core/templates/calendar-mini-widget-moon-phases.hbs
+++ b/packages/core/templates/calendar-mini-widget-moon-phases.hbs
@@ -7,7 +7,7 @@
           <div class="mini-moon-phase"
                role="img"
                aria-label="{{this.moonName}}: {{this.phaseName}}"
-               title="{{this.moonName}}: {{this.phaseName}}"
+               data-tooltip="{{this.moonName}}: {{this.phaseName}}"
                data-moon-index="{{this.moonColorIndex}}">
             <i class="fas fa-{{this.faIcon}} moon-phase-{{this.phaseIcon}}"></i>
           </div>

--- a/packages/core/templates/calendar-mini-widget.hbs
+++ b/packages/core/templates/calendar-mini-widget.hbs
@@ -7,14 +7,14 @@
       {{#if showDayOfWeek}}
         <div class="mini-weekday">{{weekdayDisplay}}</div>
       {{/if}}
-      <div class="mini-date" data-action="openCalendarSelection" title="{{shortDate}} (Click for larger view, Double-click to change calendar)">
+      <div class="mini-date" data-action="openCalendarSelection" data-tooltip="{{shortDate}} (Click for larger view, Double-click to change calendar)">
         {{shortDate}}{{#if showTime}}<span class="mini-time"> {{timeString}}</span>{{/if}}
       </div>
       {{#if isGM}}
         <div class="mini-play-pause-controls">
-          <button data-action="toggleTimeAdvancement" 
+          <button data-action="toggleTimeAdvancement"
                   class="play-pause-btn {{#if timeAdvancementActive}}active{{/if}}"
-                  title="{{#if timeAdvancementActive}}Pause{{else}}Play{{/if}} time advancement ({{advancementRatioDisplay}})">
+                  data-tooltip="{{#if timeAdvancementActive}}Pause{{else}}Play{{/if}} time advancement ({{advancementRatioDisplay}})">
             <i class="fas fa-{{#if timeAdvancementActive}}pause{{else}}play{{/if}}"></i>
           </button>
         </div>
@@ -28,11 +28,11 @@
         {{#if showTimeControls}}
           <div class="mini-time-controls">
             {{#each (getQuickTimeButtons true)}}
-              <button data-action="advanceTime" 
-                      data-amount="{{this.amount}}" 
+              <button data-action="advanceTime"
+                      data-amount="{{this.amount}}"
                       data-unit="{{this.unit}}"
                       class="{{#if (lt this.amount 0)}}rewind{{/if}}"
-                      title="{{#if (lt this.amount 0)}}Go back{{else}}Advance{{/if}} {{this.label}}">
+                      data-tooltip="{{#if (lt this.amount 0)}}Go back{{else}}Advance{{/if}} {{this.label}}">
                 <i class="fas fa-{{#if (lt this.amount 0)}}backward{{else}}clock{{/if}} fa-fw"></i> {{#if (lt this.amount 0)}}{{this.label}}{{else}}+{{this.label}}{{/if}}
               </button>
             {{/each}}
@@ -47,7 +47,7 @@
               <button
                 type="button"
                 class="mini-sidebar-button"
-                title="{{this.tooltip}}"
+                data-tooltip="{{this.tooltip}}"
                 data-action="clickSidebarButton"
                 data-button-name="{{this.name}}"
               >

--- a/packages/core/templates/calendar-selection-dialog.hbs
+++ b/packages/core/templates/calendar-selection-dialog.hbs
@@ -10,7 +10,7 @@
           <div class="calendar-card ui-control {{#if isCurrent}}active{{/if}} {{#if isSelected}}picked{{/if}} {{#if isVariant}}variant{{/if}} {{#if hierarchyLevel}}hierarchy-level-{{hierarchyLevel}}{{/if}} source-{{sourceType}}" 
                data-action="selectCalendar"
                data-calendar-id="{{id}}" 
-               title="{{description}}">
+               data-tooltip="{{description}}">
             
             <div class="card-header flexcol">
               <div class="calendar-title-row flexrow">
@@ -84,7 +84,7 @@
           <!-- File Picker Card -->
           <div class="calendar-card ui-control file-picker-card {{#if filePickerActive}}active{{/if}} {{#if filePickerSelected}}picked{{/if}}" 
                {{#if selectedFilePath}}data-action="selectCalendar" data-calendar-id="__FILE_PICKER__"{{else}}data-action="openFilePicker"{{/if}}
-               title="{{localize 'SEASONS_STARS.dialog.calendar_selection.custom_file_hint'}}">
+               data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.custom_file_hint'}}">
             
             <div class="card-header flexcol">
               <div class="calendar-title-row flexrow">

--- a/packages/core/templates/calendar-widget-moon-phases.hbs
+++ b/packages/core/templates/calendar-widget-moon-phases.hbs
@@ -5,7 +5,7 @@
         <div class="moon-phase"
              role="img"
              aria-label="{{this.moonName}}: {{this.phaseName}}"
-             title="{{this.moonName}}: {{this.phaseName}}"
+             data-tooltip="{{this.moonName}}: {{this.phaseName}}"
              data-moon-index="{{this.moonColorIndex}}">
           <i class="fas fa-{{this.faIcon}} moon-phase-{{this.phaseIcon}}"></i>
         </div>

--- a/packages/core/templates/calendar-widget-sidebar.hbs
+++ b/packages/core/templates/calendar-widget-sidebar.hbs
@@ -4,7 +4,7 @@
     <button
       type="button"
       class="sidebar-button"
-      title="{{#if this.tooltip}}{{this.tooltip}}{{else}}{{this.name}}{{/if}}"
+      data-tooltip="{{#if this.tooltip}}{{this.tooltip}}{{else}}{{this.name}}{{/if}}"
       data-action="clickSidebarButton"
       data-button-name="{{this.name}}"
     >

--- a/packages/core/templates/calendar-widget.hbs
+++ b/packages/core/templates/calendar-widget.hbs
@@ -10,14 +10,14 @@
     <div class="calendar-header">
       <span class="calendar-name">{{calendar.label}}</span>
       <div class="header-controls">
-        <button type="button" class="header-control-btn" data-action="switchToMini" title="Switch to Mini Widget">
+        <button type="button" class="header-control-btn" data-action="switchToMini" data-tooltip="Switch to Mini Widget">
           <i class="fas fa-compress-alt"></i>
         </button>
-        <button type="button" class="header-control-btn" data-action="switchToGrid" title="Switch to Grid Widget">
+        <button type="button" class="header-control-btn" data-action="switchToGrid" data-tooltip="Switch to Grid Widget">
           <i class="fas fa-th"></i>
         </button>
         {{#if isGM}}
-        <button type="button" class="header-control-btn" data-action="openCalendarSelection" title="Change Calendar System">
+        <button type="button" class="header-control-btn" data-action="openCalendarSelection" data-tooltip="Change Calendar System">
           <i class="fas fa-cog"></i>
         </button>
         {{/if}}
@@ -25,7 +25,7 @@
     </div>
 
     {{!-- Date Display --}}
-    <div class="date-display" data-action="openDetailedView" title="Click for detailed view">
+    <div class="date-display" data-action="openDetailedView" data-tooltip="Click for detailed view">
       <div class="main-date">{{shortDate}}</div>
       {{#if timeString}}
         <div class="time-display">
@@ -43,9 +43,9 @@
           <div class="control-group horizontal">
             <label>Time Advancement:</label>
             <div class="advancement-controls">
-              <button data-action="toggleTimeAdvancement" 
+              <button data-action="toggleTimeAdvancement"
                       class="play-pause-btn {{#if timeAdvancementActive}}active{{/if}}"
-                      title="{{#if timeAdvancementActive}}Pause automatic time advancement ({{advancementRatioDisplay}}){{else}}Play automatic time advancement ({{advancementRatioDisplay}}){{/if}}">
+                      data-tooltip="{{#if timeAdvancementActive}}Pause automatic time advancement ({{advancementRatioDisplay}}){{else}}Play automatic time advancement ({{advancementRatioDisplay}}){{/if}}">
                 <i class="fas fa-{{#if timeAdvancementActive}}pause{{else}}play{{/if}}"></i>
                 {{#if timeAdvancementActive}}Pause ({{advancementRatioDisplay}}){{else}}Play ({{advancementRatioDisplay}}){{/if}}
               </button>
@@ -64,7 +64,7 @@
                           data-amount="{{this.amount}}"
                           data-unit="{{this.unit}}"
                           class="{{#if (lt this.amount 0)}}rewind{{/if}}"
-                          title="{{#if (lt this.amount 0)}}Go back{{else}}Advance{{/if}} {{this.label}}">
+                          data-tooltip="{{#if (lt this.amount 0)}}Go back{{else}}Advance{{/if}} {{this.label}}">
                     <i class="fas fa-{{#if (lt this.amount 0)}}backward{{else}}clock{{/if}}"></i> {{this.label}}
                   </button>
                 {{/each}}
@@ -77,24 +77,24 @@
           <div class="control-group">
             <label>Date Controls:</label>
             <div class="date-buttons">
-              <button data-action="advanceDate" data-amount="1" data-unit="days" title="Advance 1 day">
+              <button data-action="advanceDate" data-amount="1" data-unit="days" data-tooltip="Advance 1 day">
                 <i class="fas fa-plus"></i> 1 Day
               </button>
-              <button data-action="advanceDate" data-amount="1" data-unit="weeks" title="Advance 1 week">
+              <button data-action="advanceDate" data-amount="1" data-unit="weeks" data-tooltip="Advance 1 week">
                 <i class="fas fa-plus"></i> 1 Week
               </button>
-              <button data-action="advanceDate" data-amount="1" data-unit="months" title="Advance 1 month">
+              <button data-action="advanceDate" data-amount="1" data-unit="months" data-tooltip="Advance 1 month">
                 <i class="fas fa-plus"></i> 1 Month
               </button>
             </div>
             <div class="date-buttons">
-              <button data-action="advanceDate" data-amount="-1" data-unit="days" class="rewind" title="Go back 1 day">
+              <button data-action="advanceDate" data-amount="-1" data-unit="days" class="rewind" data-tooltip="Go back 1 day">
                 <i class="fas fa-minus"></i> 1 Day
               </button>
-              <button data-action="advanceDate" data-amount="-1" data-unit="weeks" class="rewind" title="Go back 1 week">
+              <button data-action="advanceDate" data-amount="-1" data-unit="weeks" class="rewind" data-tooltip="Go back 1 week">
                 <i class="fas fa-minus"></i> 1 Week
               </button>
-              <button data-action="advanceDate" data-amount="-1" data-unit="months" class="rewind" title="Go back 1 month">
+              <button data-action="advanceDate" data-amount="-1" data-unit="months" class="rewind" data-tooltip="Go back 1 month">
                 <i class="fas fa-minus"></i> 1 Month
               </button>
             </div>
@@ -106,7 +106,7 @@
 
     {{!-- Additional Info --}}
     {{#if calendar.description}}
-      <div class="calendar-description" title="{{calendar.description}}">
+      <div class="calendar-description" data-tooltip="{{calendar.description}}">
         <i class="fas fa-info-circle"></i>
         <span>{{calendar.description}}</span>
       </div>

--- a/packages/core/test/calendar-widget-sidebar-template.test.ts
+++ b/packages/core/test/calendar-widget-sidebar-template.test.ts
@@ -96,7 +96,7 @@ describe('calendar-widget-sidebar template', () => {
     expect(button).toBeTruthy();
     expect(button?.getAttribute('data-action')).toBe('clickSidebarButton');
     expect(button?.getAttribute('data-button-name')).toBe('openNotes');
-    expect(button?.getAttribute('title')).toBe('Open Notes');
+    expect(button?.getAttribute('data-tooltip')).toBe('Open Notes');
   });
 
   it('never renders zero elements (regression test for #344)', () => {

--- a/packages/core/test/ui/calendar-mini-widget.test.ts
+++ b/packages/core/test/ui/calendar-mini-widget.test.ts
@@ -164,7 +164,7 @@ describe('CalendarMiniWidget', () => {
       mockElement.innerHTML = `
         <div class="calendar-mini-content">
           <div class="mini-header-row">
-            <div class="mini-date" data-action="openCalendarSelection" title="Test Date (Click for larger view, Double-click to change calendar)">
+            <div class="mini-date" data-action="openCalendarSelection" data-tooltip="Test Date (Click for larger view, Double-click to change calendar)">
               Test Date
             </div>
           </div>

--- a/packages/custom-calendar-builder/templates/calendar-builder.hbs
+++ b/packages/custom-calendar-builder/templates/calendar-builder.hbs
@@ -1,24 +1,24 @@
 <div class="calendar-builder-content">
   <!-- Toolbar -->
   <div class="calendar-builder-toolbar">
-    <button type="button" data-action="newCalendar" class="button" title="{{localize 'CALENDAR_BUILDER.app.buttons.new'}}">
+    <button type="button" data-action="newCalendar" class="button" data-tooltip="{{localize 'CALENDAR_BUILDER.app.buttons.new'}}">
       <i class="fas fa-file"></i> {{localize 'CALENDAR_BUILDER.app.buttons.new'}}
     </button>
-    <button type="button" data-action="openCalendar" class="button" title="{{localize 'CALENDAR_BUILDER.app.buttons.open'}}">
+    <button type="button" data-action="openCalendar" class="button" data-tooltip="{{localize 'CALENDAR_BUILDER.app.buttons.open'}}">
       <i class="fas fa-folder-open"></i> {{localize 'CALENDAR_BUILDER.app.buttons.open'}}
     </button>
-    <button type="button" data-action="importJson" class="button" title="{{localize 'CALENDAR_BUILDER.app.buttons.import'}}">
+    <button type="button" data-action="importJson" class="button" data-tooltip="{{localize 'CALENDAR_BUILDER.app.buttons.import'}}">
       <i class="fas fa-upload"></i> {{localize 'CALENDAR_BUILDER.app.buttons.import'}}
     </button>
     <div class="separator"></div>
-    <button type="button" data-action="exportJson" class="button" title="{{localize 'CALENDAR_BUILDER.app.buttons.export'}}" {{#unless hasContent}}disabled{{/unless}}>
+    <button type="button" data-action="exportJson" class="button" data-tooltip="{{localize 'CALENDAR_BUILDER.app.buttons.export'}}" {{#unless hasContent}}disabled{{/unless}}>
       <i class="fas fa-download"></i> {{localize 'CALENDAR_BUILDER.app.buttons.export'}}
     </button>
     <div class="separator"></div>
-    <button type="button" data-action="validateJson" class="button" title="{{localize 'CALENDAR_BUILDER.app.buttons.validate'}}" {{#unless hasContent}}disabled{{/unless}}>
+    <button type="button" data-action="validateJson" class="button" data-tooltip="{{localize 'CALENDAR_BUILDER.app.buttons.validate'}}" {{#unless hasContent}}disabled{{/unless}}>
       <i class="fas fa-check"></i> {{localize 'CALENDAR_BUILDER.app.buttons.validate'}}
     </button>
-    <button type="button" data-action="clearEditor" class="button danger" title="{{localize 'CALENDAR_BUILDER.app.buttons.clear'}}" {{#unless hasContent}}disabled{{/unless}}>
+    <button type="button" data-action="clearEditor" class="button danger" data-tooltip="{{localize 'CALENDAR_BUILDER.app.buttons.clear'}}" {{#unless hasContent}}disabled{{/unless}}>
       <i class="fas fa-trash"></i> {{localize 'CALENDAR_BUILDER.app.buttons.clear'}}
     </button>
   </div>


### PR DESCRIPTION
Replace title attributes with data-tooltip across all template files to use Foundry's native TooltipManager system.

Updated 46 occurrences across 11 files:
- Calendar builder interface
- Main calendar widget
- Mini calendar widget
- Grid calendar widget
- Calendar selection dialog
- Sidebar button components
- Moon phase displays

Fixes #377

---
Generated with [Claude Code](https://claude.ai/code)