### PR TITLE
fix: put Error object first for Errors & Echoes compatibility

### DIFF
--- a/packages/core/src/core/logger.ts
+++ b/packages/core/src/core/logger.ts
@@ -24,9 +24,18 @@ export class Logger {
 
   /**
    * Log warning messages
+   *
+   * IMPORTANT: When an Error object is provided, it's placed first so that
+   * Errors & Echoes can capture it through its console.warn patch.
    */
   static warn(message: string, data?: unknown): void {
-    console.warn(`[S&S WARNING] ${message}`, data || '');
+    // If data is an Error, put it first for E&E compatibility
+    if (data instanceof Error) {
+      console.warn(data, `[S&S WARNING] ${message}`);
+    } else {
+      console.warn(`[S&S WARNING] ${message}`, data || '');
+    }
+
     if (this.shouldShowUserNotifications()) {
       ui?.notifications?.warn(`Seasons & Stars: ${message}`);
     }
@@ -34,9 +43,18 @@ export class Logger {
 
   /**
    * Log error messages with user notification
+   *
+   * IMPORTANT: Error object is placed first so that Errors & Echoes can
+   * capture it through its console.error patch for automatic error reporting.
    */
   static error(message: string, error?: Error): void {
-    console.error(`[S&S ERROR] ${message}`, error || '');
+    // Put error first for E&E compatibility - it only captures if Error is first arg
+    if (error) {
+      console.error(error, `[S&S ERROR] ${message}`);
+    } else {
+      console.error(`[S&S ERROR] ${message}`);
+    }
+
     if (this.shouldShowUserNotifications()) {
       ui?.notifications?.error(`Seasons & Stars: ${message}`);
     }
@@ -44,9 +62,18 @@ export class Logger {
 
   /**
    * Log critical errors that require immediate user attention
+   *
+   * IMPORTANT: Error object is placed first so that Errors & Echoes can
+   * capture it through its console.error patch for automatic error reporting.
    */
   static critical(message: string, error?: Error): void {
-    console.error(`[S&S CRITICAL] ${message}`, error || '');
+    // Put error first for E&E compatibility - it only captures if Error is first arg
+    if (error) {
+      console.error(error, `[S&S CRITICAL] ${message}`);
+    } else {
+      console.error(`[S&S CRITICAL] ${message}`);
+    }
+
     // Always show critical errors regardless of settings
     ui?.notifications?.error(`Seasons & Stars: ${message}`);
   }

--- a/packages/core/test/logger.test.ts
+++ b/packages/core/test/logger.test.ts
@@ -155,7 +155,8 @@ describe('Logger', () => {
 
       Logger.error('Error message', testError);
 
-      expect(mockConsole.error).toHaveBeenCalledWith('[S&S ERROR] Error message', testError);
+      // Error object comes first for E&E compatibility
+      expect(mockConsole.error).toHaveBeenCalledWith(testError, '[S&S ERROR] Error message');
       expect(mockUI.notifications.error).toHaveBeenCalledWith('Seasons & Stars: Error message');
     });
 
@@ -166,7 +167,8 @@ describe('Logger', () => {
 
       expect(mockConsole.log).toHaveBeenCalledWith('[S&S] Message with no data', '');
       expect(mockConsole.warn).toHaveBeenCalledWith('[S&S WARNING] Warning with no data', '');
-      expect(mockConsole.error).toHaveBeenCalledWith('[S&S ERROR] Error with no data', '');
+      // When no error object provided, just the message is logged
+      expect(mockConsole.error).toHaveBeenCalledWith('[S&S ERROR] Error with no data');
     });
   });
 
@@ -180,9 +182,10 @@ describe('Logger', () => {
 
       Logger.critical('Critical error occurred', criticalError);
 
+      // Error object comes first for E&E compatibility
       expect(mockConsole.error).toHaveBeenCalledWith(
-        '[S&S CRITICAL] Critical error occurred',
-        criticalError
+        criticalError,
+        '[S&S CRITICAL] Critical error occurred'
       );
       expect(mockUI.notifications.error).toHaveBeenCalledWith(
         'Seasons & Stars: Critical error occurred'


### PR DESCRIPTION
## Summary

Update Logger methods to place Error objects as the first argument to console.error/warn calls, enabling automatic error capture by the Errors & Echoes module.

## Background

The Errors & Echoes module patches `console.error` and `console.warn` to automatically capture errors for debugging and error reporting. However, it only captures errors when the Error object is the **first** argument to these console methods.

The Logger was previously placing the message string first and the Error second, which prevented E&E from capturing any logged errors.

## Changes

- **Logger.error()**: Put Error first when present, else just message
- **Logger.warn()**: Put Error first when data is an Error instance  
- **Logger.critical()**: Put Error first when present, else just message
- Updated test expectations to match new argument order

## Testing

All 1875 tests pass including all 21 Logger tests.

## Impact

This change enables automatic error reporting for users who have Errors & Echoes installed, without requiring any modifications to the 100+ Logger call sites throughout the codebase. The Logger API remains unchanged - callers still pass message first, then Error second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)