### PR TITLE
feat(api): add Calendar Builder importJson API for external modules

### DIFF
--- a/packages/core/src/types/bridge-interfaces.d.ts
+++ b/packages/core/src/types/bridge-interfaces.d.ts
@@ -63,6 +63,11 @@ export interface SeasonsStarsAPI {
   advanceMonths(months: number): Promise<void>;
   advanceYears(years: number): Promise<void>;
   validateCalendar(calendarData: unknown): Promise<ValidationResult>;
+
+  // Calendar Builder API
+  calendarBuilder: {
+    importJson(jsonString: string, source?: string): Promise<void>;
+  };
 }
 
 export interface SeasonsStarsWidgets {

--- a/packages/core/src/types/foundry-extensions.d.ts
+++ b/packages/core/src/types/foundry-extensions.d.ts
@@ -179,6 +179,10 @@ export interface SeasonsStarsAPI {
   validateCalendar(calendarData: unknown): Promise<import('./bridge-interfaces').ValidationResult>;
   // Events API
   events: EventsAPI;
+  // Calendar Builder API
+  calendarBuilder: {
+    importJson(jsonString: string, source?: string): Promise<void>;
+  };
 }
 
 // Type guard functions (implementations in type-guards.ts)

--- a/packages/custom-calendar-builder/src/calendar-builder-app.ts
+++ b/packages/custom-calendar-builder/src/calendar-builder-app.ts
@@ -485,6 +485,37 @@ export class CalendarBuilderApp extends foundry.applications.api.HandlebarsAppli
     input.click();
   }
 
+  /**
+   * Import JSON from external source (e.g., compat module)
+   * Public method that can be called by other modules
+   *
+   * @param jsonString - The JSON string to import
+   * @param source - The source of the import (e.g., 'simple-calendar')
+   */
+  public async importFromExternal(jsonString: string, source: string): Promise<void> {
+    // Parse to validate JSON first
+    const data = JSON.parse(jsonString);
+
+    // Check for Simple Calendar format
+    if (await this._detectAndHandleSimpleCalendar(data, jsonString, `${source}-import`)) {
+      // Already handled by _detectAndHandleSimpleCalendar
+      return;
+    }
+
+    // Set the JSON content
+    this.currentJson = jsonString;
+
+    // Trigger validation
+    await this._validateCurrentJson();
+
+    // Render only if not already visible
+    if (!this.rendered) {
+      this.render(true);
+    }
+
+    this._notify(game.i18n.localize('CALENDAR_BUILDER.app.notifications.imported'));
+  }
+
   private async _handleImportedJson(text: string, filename?: string): Promise<void> {
     const data = JSON.parse(text);
 
@@ -551,8 +582,28 @@ export class CalendarBuilderApp extends foundry.applications.api.HandlebarsAppli
         : await this._selectCalendar(scExport.calendars);
     }
 
-    const converter = new SimpleCalendarConverter();
-    const result = converter.convert(calendarToConvert, filename);
+    // Try to use compat module's converter first, fall back to builtin
+    let result: any;
+    let converter: any;
+
+    try {
+      // Check for compat module's converter
+      const compatModule = (game as any)?.modules?.get('foundryvtt-simple-calendar-compat');
+      if (compatModule?.active && compatModule.api?.getConverter) {
+        converter = compatModule.api.getConverter();
+        result = converter.convert(calendarToConvert, filename);
+      } else {
+        // Fall back to builtin converter
+        converter = new SimpleCalendarConverter();
+        result = converter.convert(calendarToConvert, filename);
+      }
+    } catch (error) {
+      // If compat converter fails, warn and fall back to builtin
+      console.warn('Compat module converter failed, falling back to builtin:', error);
+      this._notify('Compat converter failed, using builtin converter', 'warn');
+      converter = new SimpleCalendarConverter();
+      result = converter.convert(calendarToConvert, filename);
+    }
 
     this.currentJson = JSON.stringify(result.calendar, null, 2);
     this.render(true);


### PR DESCRIPTION
## Summary

Adds programmatic API for importing calendar JSON into Calendar Builder, enabling compatibility modules to trigger calendar imports from their own data sources.

## Changes

### API Additions
- **`game.seasonsStars.api.calendarBuilder.importJson()`** - New API method for external modules
- **`CalendarBuilderApp.importFromExternal()`** - Public method for programmatic imports
- Updated TypeScript definitions in `foundry-extensions.d.ts` and `bridge-interfaces.d.ts`

### Implementation Details
- Accesses Calendar Builder through `window.SeasonsStarsCalendarBuilder` global to avoid cross-package import issues during Rollup build
- Gracefully handles Calendar Builder module not being loaded with clear error message
- Enhanced Simple Calendar detection in Calendar Builder to prefer compat module's converter when available

## Use Case

This API enables the Simple Calendar Compatibility Bridge to provide import buttons directly in the S&S widget sidebar, allowing users to import their Simple Calendar data into Calendar Builder with a single click.

## Testing

**API Availability:**
```javascript
// Check API is available
console.log(game.seasonsStars.api.calendarBuilder);

// Test import (requires Calendar Builder module enabled)
await game.seasonsStars.api.calendarBuilder.importJson(
  '{"id": "test", "translations": {}, "months": [], "weekdays": []}',
  'test-source'
);
```

**Error Handling:**
```javascript
// Should provide clear error if Calendar Builder not loaded
await game.seasonsStars.api.calendarBuilder.importJson('{}', 'test');
```

## Related

- Companion PR in foundryvtt-simple-calendar-compat for sidebar button integration
- Enables #[issue-number] if there's a tracking issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)