### PR TITLE
feat(fantasy-pack): add Midpeace intercalary period to Roshar calendar

### DIFF
--- a/packages/fantasy-pack/calendars/roshar.json
+++ b/packages/fantasy-pack/calendars/roshar.json
@@ -114,6 +114,12 @@
 
   "intercalary": [
     {
+      "name": "Midpeace",
+      "days": 28,
+      "after": "Palah",
+      "description": "A four-week period with no highstorms occurring at the midpoint of the year, halfway between Weepings. The Middlefest fair in Jah Keved is held during this time."
+    },
+    {
       "name": "The Weeping",
       "days": 28,
       "after": "Ishev",

--- a/packages/fantasy-pack/test/roshar-calendar.test.ts
+++ b/packages/fantasy-pack/test/roshar-calendar.test.ts
@@ -38,10 +38,12 @@ describe('Roshar Calendar', () => {
       expect(rosharCalendar.weekdays).toHaveLength(5);
     });
 
-    it('should have The Weeping as intercalary period', () => {
-      expect(rosharCalendar.intercalary).toHaveLength(1);
-      expect(rosharCalendar.intercalary[0].name).toBe('The Weeping');
+    it('should have both Midpeace and The Weeping as intercalary periods', () => {
+      expect(rosharCalendar.intercalary).toHaveLength(2);
+      expect(rosharCalendar.intercalary[0].name).toBe('Midpeace');
       expect(rosharCalendar.intercalary[0].days).toBe(28);
+      expect(rosharCalendar.intercalary[1].name).toBe('The Weeping');
+      expect(rosharCalendar.intercalary[1].days).toBe(28);
     });
   });
 
@@ -194,9 +196,19 @@ describe('Roshar Calendar', () => {
     });
   });
 
-  describe('Intercalary Period - The Weeping', () => {
+  describe('Intercalary Periods', () => {
+    it('should have Midpeace configured correctly', () => {
+      const midpeace = rosharCalendar.intercalary[0];
+
+      expect(midpeace.name).toBe('Midpeace');
+      expect(midpeace.days).toBe(28);
+      expect(midpeace.after).toBe('Palah');
+      expect(midpeace.description).toContain('four-week period with no highstorms');
+      expect(midpeace.description).toContain('Middlefest');
+    });
+
     it('should have The Weeping configured correctly', () => {
-      const weeping = rosharCalendar.intercalary[0];
+      const weeping = rosharCalendar.intercalary[1];
 
       expect(weeping.name).toBe('The Weeping');
       expect(weeping.days).toBe(28);


### PR DESCRIPTION
Adds Midpeace, a four-week intercalary period with no highstorms, to the Roshar calendar. This period occurs at the midpoint of the year (after Palah/month 5), halfway between the two Weepings.

Verified from the [Stormlight Archive Wiki](https://stormlightarchive.fandom.com/wiki/Calendar).

Fixes #434

🤖 Generated with [Claude Code](https://claude.ai/code)