### PR TITLE
fix: remove redundant 30-second auto-update from CalendarWidget

### DIFF
--- a/packages/core/src/ui/calendar-widget.ts
+++ b/packages/core/src/ui/calendar-widget.ts
@@ -19,7 +19,6 @@ import type { MainWidgetContext } from '../types/widget-types';
 export class CalendarWidget extends foundry.applications.api.HandlebarsApplicationMixin(
   foundry.applications.api.ApplicationV2
 ) {
-  private updateInterval: number | null = null;
   private static activeInstance: CalendarWidget | null = null;
   private lastRenderContext?: MainWidgetContext;
 
@@ -298,9 +297,6 @@ export class CalendarWidget extends foundry.applications.api.HandlebarsApplicati
     if (partId === 'moonPhases' && this.lastRenderContext) {
       this.applyMoonPhaseColors(this.lastRenderContext);
     }
-
-    // Start auto-update after rendering
-    this.startAutoUpdate();
   }
 
   /**
@@ -636,37 +632,9 @@ export class CalendarWidget extends foundry.applications.api.HandlebarsApplicati
   }
 
   /**
-   * Start automatic updates
-   */
-  private startAutoUpdate(): void {
-    if (this.updateInterval) {
-      clearInterval(this.updateInterval);
-    }
-
-    // Update every 30 seconds
-    this.updateInterval = window.setInterval(() => {
-      if (this.rendered) {
-        this.render();
-      }
-    }, 30000);
-  }
-
-  /**
-   * Stop automatic updates
-   */
-  private stopAutoUpdate(): void {
-    if (this.updateInterval) {
-      clearInterval(this.updateInterval);
-      this.updateInterval = null;
-    }
-  }
-
-  /**
    * Handle closing the widget
    */
   async close(options: any = {}): Promise<this> {
-    this.stopAutoUpdate();
-
     // Clear active instance if this is it
     if (CalendarWidget.activeInstance === this) {
       CalendarWidget.activeInstance = null;


### PR DESCRIPTION
## Summary
Removes the 30-second auto-update interval from CalendarWidget as it's redundant with the existing hook-based update system.

## Problem
The widget was re-rendering every 30 seconds via `setInterval`, which was:
- Redundant with hook-based updates
- Creating unnecessary performance overhead
- Potentially causing race conditions with element availability

## Solution
Remove the auto-update mechanism entirely and rely on the existing hooks:
- `seasons-stars:dateChanged` - time changes
- `seasons-stars:calendarChanged` - calendar changes
- `combatStart` / `deleteCombat` - combat state changes
- `seasons-stars:settingsChanged` - settings updates
- `seasons-stars:widgetButtonsChanged` - button registry changes

## Changes
- Removed `updateInterval` property
- Removed `startAutoUpdate()` and `stopAutoUpdate()` methods
- Removed auto-update setup in `_attachPartListeners()`
- Removed auto-update cleanup in `close()`
- Deleted obsolete auto-update test file

## Benefits
- More responsive updates (immediate via hooks vs 30-second delay)
- Better performance (no redundant renders)
- Simpler codebase (less state to manage)
- Correct architectural pattern for Foundry VTT

## Test Plan
- [x] All 2286 tests pass
- [x] Linter passes
- [x] Type checker passes
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)