### PR TITLE
fix(ui): scope .dialog-buttons selector to prevent global CSS leak

### DIFF
--- a/packages/core/src/styles/calendar-selection-dialog.scss
+++ b/packages/core/src/styles/calendar-selection-dialog.scss
@@ -496,6 +496,42 @@
       }
     }
   }
+
+  .dialog-buttons {
+    padding: 1rem;
+    gap: 0.75rem;
+    justify-content: flex-end;
+    margin-top: auto;
+
+    button {
+      padding: 0.5rem 1rem;
+      font-size: 0.9rem;
+
+      i {
+        margin-right: 0.5rem;
+      }
+
+      &.ss-button.primary {
+        background: var(--color-warm-2) !important;
+        color: white !important;
+        border-color: var(--color-warm-2) !important;
+        font-weight: 600;
+
+        &:hover {
+          background: var(--color-warm-1) !important;
+          border-color: var(--color-warm-1) !important;
+          color: white !important;
+        }
+
+        &:disabled {
+          opacity: 0.6;
+          background: var(--color-bg-alt) !important;
+          color: var(--color-text-light-secondary) !important;
+          border-color: var(--color-border-light-secondary) !important;
+        }
+      }
+    }
+  }
 }
 
 // Calendar Preview Dialog Styles
@@ -611,40 +647,39 @@
       }
     }
   }
-}
 
-// Dialog footer buttons
-.dialog-buttons {
-  padding: 1rem;
-  gap: 0.75rem;
-  justify-content: flex-end;
-  margin-top: auto;
-  
-  button {
-    padding: 0.5rem 1rem;
-    font-size: 0.9rem;
-    
-    i {
-      margin-right: 0.5rem;
-    }
-    
-    &.ss-button.primary {
-      background: var(--color-warm-2) !important;
-      color: white !important;
-      border-color: var(--color-warm-2) !important;
-      font-weight: 600;
-      
-      &:hover {
-        background: var(--color-warm-1) !important;
-        border-color: var(--color-warm-1) !important;
-        color: white !important;
+  .dialog-buttons {
+    padding: 1rem;
+    gap: 0.75rem;
+    justify-content: flex-end;
+    margin-top: auto;
+
+    button {
+      padding: 0.5rem 1rem;
+      font-size: 0.9rem;
+
+      i {
+        margin-right: 0.5rem;
       }
-      
-      &:disabled {
-        opacity: 0.6;
-        background: var(--color-bg-alt) !important;
-        color: var(--color-text-light-secondary) !important;
-        border-color: var(--color-border-light-secondary) !important;
+
+      &.ss-button.primary {
+        background: var(--color-warm-2) !important;
+        color: white !important;
+        border-color: var(--color-warm-2) !important;
+        font-weight: 600;
+
+        &:hover {
+          background: var(--color-warm-1) !important;
+          border-color: var(--color-warm-1) !important;
+          color: white !important;
+        }
+
+        &:disabled {
+          opacity: 0.6;
+          background: var(--color-bg-alt) !important;
+          color: var(--color-text-light-secondary) !important;
+          border-color: var(--color-border-light-secondary) !important;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes the CSS scoping issue that was causing the D&D 5e roll configuration dialog to be scaled incorrectly.

## Changes

- Scoped `.dialog-buttons` selector under `.seasons-stars.calendar-selection-dialog`
- Scoped `.dialog-buttons` selector under `.seasons-stars.calendar-preview-dialog`
- This prevents the selector from affecting all Foundry dialogs globally

## Testing

- All lint, typecheck, build, and test checks pass
- 2294 tests passed

Fixes #485

----

Generated with [Claude Code](https://claude.ai/code)