### PR TITLE
feat: add support for 12-hour clock format with am/pm notation

### DIFF
--- a/docs/DEVELOPER-GUIDE.md
+++ b/docs/DEVELOPER-GUIDE.md
@@ -1754,6 +1754,10 @@ interface SeasonsStarsCalendar {
     hoursInDay: number; // Usually 24
     minutesInHour: number; // Usually 60
     secondsInMinute: number; // Usually 60
+    amPmNotation?: {
+      am: string; // Text for ante meridiem (e.g., "AM", "a.m.")
+      pm: string; // Text for post meridiem (e.g., "PM", "p.m.")
+    }; // Optional AM/PM notation for 12-hour clock display
   }; // Defaults to 24/60/60
 
   // Optional canonical hours for time period naming (added in v0.8.0)

--- a/package-lock.json
+++ b/package-lock.json
@@ -131,7 +131,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -387,6 +386,7 @@
       "integrity": "sha512-8EzdeIoWPJDsMBwz3zdzwXnUpCzMiCyz5/A3FIPpriaclFCGDkAzK13sMcnsu5rowqiyeQN2Vs2TsOcoDPZirQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -400,6 +400,7 @@
       "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.4.0",
@@ -413,6 +414,7 @@
       "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.0.0",
@@ -427,6 +429,7 @@
       "integrity": "sha512-h/SceTVsN5r+WE+TVP2g3KDvNoSzbSrtZXCKo4vkKdbfT5t4otuVgngGdFukOO/rwRD2++pCxoh6xD4TEVMkQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/lang-css": "^6.0.0",
@@ -445,6 +448,7 @@
       "integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/language": "^6.6.0",
@@ -461,6 +465,7 @@
       "integrity": "sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@lezer/json": "^1.0.0"
@@ -472,6 +477,7 @@
       "integrity": "sha512-fBm0BO03azXnTAsxhONDYHi/qWSI+uSEIpzKM7h/bkIc9fHnFp9y7KTMXKON0teNT97pFhc1a9DQTtWBYEZ7ug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.7.1",
         "@codemirror/lang-html": "^6.0.0",
@@ -488,6 +494,7 @@
       "integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -503,6 +510,7 @@
       "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.35.0",
@@ -515,6 +523,7 @@
       "integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -527,6 +536,7 @@
       "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -537,6 +547,7 @@
       "integrity": "sha512-bTWAJxL6EOFLPzTx+O5P5xAO3gTqpatQ2b/ARQ8itfU/v2LlpS3pH2fkL0A3E/Fx8Y2St2KES7ZEV0sHTsSW/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -632,7 +643,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -679,7 +689,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1479,7 +1488,8 @@
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
       "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@lezer/css": {
       "version": "1.3.0",
@@ -1487,6 +1497,7 @@
       "integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -1499,6 +1510,7 @@
       "integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -1509,6 +1521,7 @@
       "integrity": "sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -1521,6 +1534,7 @@
       "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.1.3",
@@ -1533,6 +1547,7 @@
       "integrity": "sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.2.0",
         "@lezer/highlight": "^1.0.0",
@@ -1545,6 +1560,7 @@
       "integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -1555,6 +1571,7 @@
       "integrity": "sha512-kfw+2uMrQ/wy/+ONfrH83OkdFNM0ye5Xq96cLlaCy7h5UT9FO54DU4oRoIc0CSBh5NWmWuiIJA7NGLMJbQ+Oxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0"
@@ -1565,7 +1582,8 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -1921,6 +1939,7 @@
       "integrity": "sha512-oRyzXE7nirAn+5yYjCdWQHg3EG2XXcYRoYNOK8Quqnmm+9FyK/2YWVunwudlYl++M3xY+gIAdf0vAYS+p0nKfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "semver": "7.6.3"
       },
@@ -1934,6 +1953,7 @@
       "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1947,6 +1967,7 @@
       "integrity": "sha512-tCr0yeWpMe0yucFvEPidy5a7gVJGpTjqGrDpSEBYT/kbScfUwcoX49RrckCCCiXDlyO4WRh9lVVuHXTvqRLIMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
@@ -1959,6 +1980,7 @@
       "integrity": "sha512-opyWMuO0Ir8pf1DYUR++wAA6ZfNU+nIX2z95R2OD172HbcdhB4/HD7leLIIAny/LciEdMqlWEBhXK7N93YWbdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -1982,6 +2004,7 @@
       "resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-basis.git#d0956799d7c23f59e12b7b2ec4dc21c041180b0e",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/assets": "github:foundry-vtt-types/pixi-assets#main",
         "@pixi/compressed-textures": "github:foundry-vtt-types/pixi-compressed-textures#main",
@@ -1994,6 +2017,7 @@
       "integrity": "sha512-a6R+bXKeXMDcRmjYQoBIK+v2EYqxSX49wcjAY579EYM/WrFKS98nSees6lqVUcLKrcQh2DT9srJHX7XMny3voQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/colord": "^2.9.6"
       }
@@ -2003,7 +2027,8 @@
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
       "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/compressed-textures": {
       "version": "7.4.3",
@@ -2073,7 +2098,8 @@
       "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.4.3.tgz",
       "integrity": "sha512-FhoiYkHQEDYHUE7wXhqfsTRz6KxLXjuMbSiAwnLb9uG1vAgp6q6qd6HEsf4X30YaZbLFY8a4KY6hFZWjF+4Fdw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/extract": {
       "version": "7.4.3",
@@ -2081,6 +2107,7 @@
       "integrity": "sha512-HNvGNrEVaeVsbcnIO1MsHpjZbTwo9nIlaOEBzDGcL6JWwzuB1RnzUke7WUCndCUt91sGUdvPnvgCvy9/NNFg3w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3"
       }
@@ -2091,6 +2118,7 @@
       "integrity": "sha512-YFdUB1I53USQb+9TEhS849dV2KZhbnNGIoBbOSThUJfXQc4pDguIFWMagVToAQYgmZ4C4AtYfVjaSEELrMcCdA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3"
       }
@@ -2101,6 +2129,7 @@
       "integrity": "sha512-ZFzS9L/whdRbs5A/EUgF3yQaBcxNarmbuwaMgrfnpQ84mRczkGByqDLGToadiufyals07ufTrXBGRle9lbtEDA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3"
       }
@@ -2111,6 +2140,7 @@
       "integrity": "sha512-TNu0h20SrzjUWIb5v19dAp1vPpqtG0w2XF9kIHN91bMNaf3R1jzhpWG6TtaVO9eo1IolWcEJLw38jIohyC+KNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3"
       }
@@ -2121,6 +2151,7 @@
       "integrity": "sha512-ax+cFA2mEnKgqf9F8qInpv09GNWzjwnASLETpwPXzWBtlAlNCeHV2tCv3+SlMdEKUkwG9sA7AmjjjC2JBUyt+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3"
       }
@@ -2131,6 +2162,7 @@
       "integrity": "sha512-y9jhho5cCflhEsPtNqqsd+XJHsb+/ysht4rG/VHQ8Z6pScHYpbgiEpowryGq8uSMQQwx6zKNS2DPiXdiOHPZsg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3"
       }
@@ -2141,6 +2173,7 @@
       "integrity": "sha512-rwgSO3BKe1jW/P5CaOcfLKjfpl674aBEo/igi/3QLxA3ORhILNqWRsKkOwP8xF/ejI5NE4rMEkdv0LScbdGFhA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3"
       }
@@ -2164,6 +2197,7 @@
       "integrity": "sha512-9xIFWZhHGEb6KCnyWL6TVPYG/QkF0YDM/yDU5EvjTQbaj/1cITrXtI5P3tBkB5H0DQi+8J8/QS38MjfqNEJAYQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "^7.2.0",
         "@pixi/display": "^7.2.0",
@@ -2196,6 +2230,7 @@
       "integrity": "sha512-EqpxpVZoTObyupxMSzuUsCGmWPQioW84n9EO9Ajawkk/HYA+qKFZ5viKiEThIUBYgv4Apn/7c0U3Feg7Ez4uQQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/mesh": "7.4.3"
@@ -2207,6 +2242,7 @@
       "integrity": "sha512-NgvDdgSgd2tfcTSc+SWF12JJjVVz5ZrkSlhX0idSp/LSako82AiFJlD2xqH9GUsEcA6sqBBlnu7nrGkPTHQdhA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
@@ -2219,6 +2255,7 @@
       "integrity": "sha512-HLhDxHwafQT+CxbqQx9w9ivJIyAOg9JJ/6m4fNymVuDWeuMGcxDxBD7DukdUYIieT+RD/RlxdPEmq8YoromlFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/display": "7.4.3"
       }
@@ -2229,6 +2266,7 @@
       "integrity": "sha512-k09kvkS379EypCIWgXMY7uiXtWk1BsaJyTYlV16Co0AsmNPdFd+wUozMx1xV6rxcGiWXsxr/1k9fbETuYkcXCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3"
@@ -2240,6 +2278,7 @@
       "integrity": "sha512-0DfJF5C0XTfuI2FsLYvMKCOtqWjXWGOWfA6m4l0W/Ke/qw5zKIOEhgjPLw4qNRtOhmEfkVKJUGp66Ap/ya2YzA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
@@ -2251,6 +2290,7 @@
       "resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-particle-emitter.git#9bd3cb53826b2c7d4c407db183f4dd93edd50aae",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/constants": ">=6.0.4 <8.0.0",
         "@pixi/core": "github:foundry-vtt-types/pixi-core#main",
@@ -2273,6 +2313,7 @@
       "integrity": "sha512-OjJHGKXPzwP5OLKxBnTBnKMOktHynLvO0TQPqTYgNtmGQzY109mypCqM4M+s/V+uYmBo/T+sXvBahj98q/f1tA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
@@ -2285,7 +2326,8 @@
       "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.4.3.tgz",
       "integrity": "sha512-TJyfp7y23u5vvRAyYhVSa7ytq0PdKSvPLXu4G3meoFh1oxTLHH6g/RIzLuxUAThPG2z7ftthuW3qWq6dRV+dhw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pixi/settings": {
       "version": "7.4.3",
@@ -2293,6 +2335,7 @@
       "integrity": "sha512-SmGK8smc0PxRB9nr0UJioEtE9hl4gvj9OedCvZx3bxBwA3omA5BmP3CyhQfN8XJ29+o2OUL01r3zAPVol4l4lA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/constants": "7.4.3",
         "@types/css-font-loading-module": "^0.0.12",
@@ -2317,6 +2360,7 @@
       "integrity": "sha512-mw5YIec8KfO1Jv9qrDNvGoD7Dlmcgww5YlMtd+ARi7Zzo+6ziNw899LXtoaKX1+3BXdZbYNyJAx3C5r30NtwXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/sprite": "7.4.3"
@@ -2328,6 +2372,7 @@
       "integrity": "sha512-kUa9cEcMsGXSIZoXA7LhW4oo0eWa30w0KYd7mZ0bqalBMfOcvsGZMN701Lc5lpE8URw+8yu5bnyGLbrxhWBTuw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
@@ -2340,6 +2385,7 @@
       "integrity": "sha512-Ce4xZzUxUSKfiROUjjVCBYNLuCcDEWKJ822bSV9rkgVHItu3q04VnEww0DXO+9K0hKv4Ukjjk8aP6Pz0LgPm7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/assets": "7.4.3",
         "@pixi/core": "7.4.3"
@@ -2363,6 +2409,7 @@
       "integrity": "sha512-TnBocJm7f5nMAYwYcsojc62uCrOYauAGH26o3pNrlqmHDRDQ7FzPOGvkYZGYFREbUycloLSRlYpSy0FB9ZdV4Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/assets": "7.4.3",
         "@pixi/core": "7.4.3",
@@ -2377,6 +2424,7 @@
       "integrity": "sha512-nm9K9gjSZAU8ETwQZBE3kMGNdO1IzyghxoRTcJCWKhekiGDpUQhopfNhqieNZ7reVJpvhpFQWjbyaHDehndUaQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.4.3",
         "@pixi/display": "7.4.3",
@@ -2401,6 +2449,7 @@
       "resolved": "git+ssh://git@github.com/foundry-vtt-types/pixi-utils.git#8274a744f353ec7a7d9313748ceab22455df8837",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@pixi/color": "7.4.3",
         "@pixi/constants": "7.4.3",
@@ -3407,7 +3456,8 @@
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.2",
@@ -3435,6 +3485,7 @@
       "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3444,7 +3495,8 @@
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.12.tgz",
       "integrity": "sha512-x2tZZYkSxXqWvTDgveSynfjq/T2HyiZHXb00j/+gy19yp70PHCizM48XFdjBCWH7eHBD0R5i/pw9yMBP/BH5uA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -3465,7 +3517,8 @@
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
       "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3548,7 +3601,8 @@
       "resolved": "https://registry.npmjs.org/@types/showdown/-/showdown-2.0.6.tgz",
       "integrity": "sha512-pTvD/0CIeqe4x23+YJWlX2gArHa8G0J0Oh6GKaVXV7TAeickpkkZiNOgFcFcmLQ5lB/K0qBJL1FtRYltBfbGCQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/simple-peer": {
       "version": "9.11.8",
@@ -3556,6 +3610,7 @@
       "integrity": "sha512-rvqefdp2rvIA6wiomMgKWd2UZNPe6LM2EV5AuY3CPQJF+8TbdrL5TjYdMf0VAjGczzlkH4l1NjDkihwbj3Xodw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3572,7 +3627,8 @@
       "resolved": "https://registry.npmjs.org/@types/youtube/-/youtube-0.0.50.tgz",
       "integrity": "sha512-d4GpH4uPYp9W07kc487tiq6V/EUHl18vZWFMbQoe4Sk9LXEWzFi/BMf9x7TI4m7/j7gU3KeX8H6M8aPBgykeLw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.44.0",
@@ -3620,7 +3676,6 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -4020,6 +4075,7 @@
       "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -4034,6 +4090,7 @@
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4044,6 +4101,7 @@
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -4057,7 +4115,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4288,7 +4345,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/base64id": {
       "version": "2.0.0",
@@ -4296,6 +4354,7 @@
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
@@ -4377,7 +4436,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -4412,6 +4470,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -4433,6 +4492,7 @@
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -4447,6 +4507,7 @@
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -4610,6 +4671,7 @@
       "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -4684,6 +4746,7 @@
       "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -4694,6 +4757,7 @@
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
@@ -4707,7 +4771,8 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4852,6 +4917,7 @@
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -4867,6 +4933,7 @@
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -4885,7 +4952,8 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
@@ -4893,6 +4961,7 @@
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -4909,6 +4978,7 @@
       "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -4937,6 +5007,7 @@
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -4951,7 +5022,8 @@
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -4980,6 +5052,7 @@
       "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
@@ -5001,6 +5074,7 @@
       "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1",
@@ -5015,6 +5089,7 @@
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5033,6 +5108,7 @@
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5055,6 +5131,7 @@
       "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -5065,6 +5142,7 @@
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5083,6 +5161,7 @@
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5130,7 +5209,8 @@
       "resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
       "integrity": "sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -5138,6 +5218,7 @@
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5148,6 +5229,7 @@
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -5165,6 +5247,7 @@
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -5243,7 +5326,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5304,7 +5386,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -5452,7 +5533,8 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/expect-type": {
       "version": "1.2.2",
@@ -5791,7 +5873,8 @@
       "resolved": "https://registry.npmjs.org/get-browser-rtc/-/get-browser-rtc-1.1.0.tgz",
       "integrity": "sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/get-east-asian-width": {
       "version": "1.4.0",
@@ -5812,6 +5895,7 @@
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -5837,6 +5921,7 @@
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -5932,6 +6017,7 @@
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -5959,6 +6045,7 @@
       "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -5981,6 +6068,7 @@
       "integrity": "sha512-XjamtPHDO56u/iI37UAl8bKJjzCtfDJJzx1QW+OlUm8dYqAKJ2RKjoI9qAdDrwORpiMjA4olqjWnQlJ9P5GFWw==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "intl-format-cache": "2.0.5",
         "intl-messageformat": "1.1.0",
@@ -6003,6 +6091,7 @@
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -6056,6 +6145,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
@@ -6069,6 +6159,7 @@
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -6152,7 +6243,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -6222,7 +6314,8 @@
       "resolved": "https://registry.npmjs.org/intl-format-cache/-/intl-format-cache-2.0.5.tgz",
       "integrity": "sha512-xYPMygEcyGQvCsSKtpJz5ftsqLBID8t4p+ZqMLmwiE6pxkIVfTHOPF/jAA+X+bJzAnjBMps/GelH8eO9eYovRQ==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/intl-messageformat": {
       "version": "1.1.0",
@@ -6230,6 +6323,7 @@
       "integrity": "sha512-uw+PsxKM1i0Bj3bd8Y0Rkfm6SYtl9TucmslrUDIHHhz3sKKUs6sdRX+0OOx/cV9cHwAQ0hzGg0A0nswT6ZWFTA==",
       "dev": true,
       "license": "BSD",
+      "peer": true,
       "dependencies": {
         "intl-messageformat-parser": "1.1.0"
       }
@@ -6240,7 +6334,8 @@
       "integrity": "sha512-Dy5x2puv9ne6KUvEkZGq781p8iA4nB8BUrRUnacrgCeLv39KAGLPTiGf+18OLxa+PJ8cXnEyiGSSlIku3ZTuUA==",
       "deprecated": "We've written a new parser that's 6x faster and is backwards compatible. Please use @formatjs/icu-messageformat-parser",
       "dev": true,
-      "license": "BSD"
+      "license": "BSD",
+      "peer": true
     },
     "node_modules/intl-relativeformat": {
       "version": "1.1.0",
@@ -6249,6 +6344,7 @@
       "deprecated": "This package has been deprecated, please see migration guide at 'https://github.com/formatjs/formatjs/tree/master/packages/intl-relativeformat#migration-guide'",
       "dev": true,
       "license": "BSD",
+      "peer": true,
       "dependencies": {
         "intl-messageformat": "1.1.0"
       }
@@ -6377,7 +6473,8 @@
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
       "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -6454,7 +6551,8 @@
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
@@ -6482,7 +6580,6 @@
       "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/dom-selector": "^6.7.2",
         "cssstyle": "^5.3.1",
@@ -6810,6 +6907,7 @@
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6877,6 +6975,7 @@
       "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6887,6 +6986,7 @@
       "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
       },
@@ -6926,6 +7026,7 @@
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7002,6 +7103,7 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7011,7 +7113,8 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/node-addon-api": {
       "version": "7.1.1",
@@ -7097,6 +7200,7 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7107,6 +7211,7 @@
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7180,7 +7285,8 @@
       "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -7239,7 +7345,8 @@
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
       "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -7341,6 +7448,7 @@
       "integrity": "sha512-ZjzyJYY8NqW8JOZr2PbS/J0UH/hnfGALxSDsBUVQg5Y/I+ZaPuGeBJ7EclUX2RvWjhlsi4pnuL1C/K/3u+cDeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@peggyjs/from-mem": "1.3.5",
         "commander": "^12.1.0",
@@ -7359,6 +7467,7 @@
       "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7402,6 +7511,7 @@
       "integrity": "sha512-/1fa2YjjfYTG3AZlvnLu1B0uZPgXuFY2zijoy/VoUwGokHQ6HwLy0LtVVxFWK9Vwl5zGSRJnGpEV0/34ydKfog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18",
         "npm": ">=8",
@@ -7521,7 +7631,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7547,7 +7656,6 @@
       "integrity": "sha512-QgODejq9K3OzoBbuyobZlUhznP5SKwPqp+6Q6xw6o8gnhr4O85L2U915iM2IDcfF2NPXVaM9zlo9tdwipnYwzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7587,6 +7695,7 @@
       "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0"
       }
@@ -7597,6 +7706,7 @@
       "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -7609,6 +7719,7 @@
       "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.1.0",
@@ -7621,6 +7732,7 @@
       "integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.0.0",
         "prosemirror-model": "^1.0.0",
@@ -7634,6 +7746,7 @@
       "integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.2.2",
         "prosemirror-transform": "^1.0.0",
@@ -7647,6 +7760,7 @@
       "integrity": "sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "prosemirror-transform": "^1.0.0"
@@ -7658,6 +7772,7 @@
       "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-state": "^1.0.0",
         "w3c-keyname": "^2.2.0"
@@ -7669,6 +7784,7 @@
       "integrity": "sha512-dY2HdaNXlARknJbrManZ1WyUtos+AP97AmvqdOQtWtrrC5g4mohVX5DTi9rXNFSk09eczLq9GuNTtq3EfMeMGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -7679,6 +7795,7 @@
       "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-state": "^1.0.0",
@@ -7691,6 +7808,7 @@
       "integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -7703,6 +7821,7 @@
       "integrity": "sha512-DAgDoUYHCcc6tOGpLVPSU1k84kCUWTWnfWX3UDy2Delv4ryH0KqTD6RBI6k4yi9j9I8gl3j8MkPpRD/vWPZbug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-keymap": "^1.2.2",
         "prosemirror-model": "^1.25.0",
@@ -7717,6 +7836,7 @@
       "integrity": "sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.21.0"
       }
@@ -7727,6 +7847,7 @@
       "integrity": "sha512-cViIhlt1/T5bQMINrmXh43JZcdIgdW1YkOABmIuH5gSt3/HiCZHsLN9d5GvsgzrXn2+zZ8il0kkghisusm7tSA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -7773,6 +7894,7 @@
       "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -7810,6 +7932,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -7820,6 +7943,7 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7946,7 +8070,6 @@
       "integrity": "sha512-+IuescNkTJQgX7AkIDtITipZdIGcWF0pnVvZTWStiazUmcGA2ag8dfg0urest2XlXUi9kuhfQ+qmdc5Stc3z7g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8063,7 +8186,8 @@
       "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
@@ -8115,7 +8239,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8130,6 +8255,7 @@
       "integrity": "sha512-dLAADUSS8rBwhaevT12yCezvioCA+bmUTPH/u57xKPT8d++voeYE6HeluA/bPbQ15TwDBG2ii+QZIEmYx8VdxA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -8145,6 +8271,7 @@
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8275,6 +8402,7 @@
       "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "^9.0.0"
       },
@@ -8292,6 +8420,7 @@
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8302,6 +8431,7 @@
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -8322,6 +8452,7 @@
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -8339,6 +8470,7 @@
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -8358,6 +8490,7 @@
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -8412,6 +8545,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer": "^6.0.3",
         "debug": "^4.3.2",
@@ -8483,6 +8617,7 @@
       "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
@@ -8502,6 +8637,7 @@
       "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "~4.3.4",
         "ws": "~8.17.1"
@@ -8513,6 +8649,7 @@
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -8531,6 +8668,7 @@
       "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8553,6 +8691,7 @@
       "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.2",
@@ -8569,6 +8708,7 @@
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -8587,6 +8727,7 @@
       "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
@@ -8601,6 +8742,7 @@
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -8619,6 +8761,7 @@
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -8637,6 +8780,7 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8647,6 +8791,7 @@
       "integrity": "sha512-psgxdGMwl5MZM9S3FWee4EgsEaIjahYV5AzGnwUvPhWeITz/j6rKpysQHlQ4USdxvINlb8lKfWGIXwfkrgtqkA==",
       "dev": true,
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -8666,7 +8811,8 @@
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
       "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
       "dev": true,
-      "license": "(WTFPL OR MIT)"
+      "license": "(WTFPL OR MIT)",
+      "peer": true
     },
     "node_modules/stackback": {
       "version": "0.0.2",
@@ -8688,6 +8834,7 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -8839,7 +8986,8 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
       "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -8992,7 +9140,8 @@
       "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.6.tgz",
       "integrity": "sha512-++XYEs8lKWvZxDCjrr8Baiw7KiikraZ5JkLMg6EdnUVNKJui0IsrAADj5MsyUeFkcEryfn2jd3p09H7REvewyg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinypool": {
       "version": "1.1.1",
@@ -9146,6 +9295,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9163,6 +9313,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9180,6 +9331,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9197,6 +9349,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9214,6 +9367,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9231,6 +9385,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9248,6 +9403,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9265,6 +9421,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9282,6 +9439,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9299,6 +9457,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9316,6 +9475,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9333,6 +9493,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9350,6 +9511,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9367,6 +9529,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9384,6 +9547,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9401,6 +9565,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9418,6 +9583,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9435,6 +9601,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9452,6 +9619,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9469,6 +9637,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9486,6 +9655,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9503,6 +9673,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9520,6 +9691,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9537,6 +9709,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9554,6 +9727,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9571,6 +9745,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -9636,7 +9811,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9746,6 +9920,7 @@
       "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.12.3"
@@ -9759,14 +9934,16 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -9774,6 +9951,7 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9784,7 +9962,6 @@
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -9955,7 +10132,8 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
@@ -10089,7 +10267,8 @@
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "9.0.2",
@@ -10265,6 +10444,7 @@
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
       "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10282,7 +10462,6 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/packages/core/calendars/gregorian.json
+++ b/packages/core/calendars/gregorian.json
@@ -184,7 +184,11 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "moons": [

--- a/packages/core/languages/en.json
+++ b/packages/core/languages/en.json
@@ -100,6 +100,7 @@
         "toggle_year": "Toggle Year",
         "toggle_moon_phases": "Toggle Moon Phases",
         "toggle_sunrise_sunset": "Toggle Sunrise/Sunset",
+        "toggle_12hour": "Toggle 12-Hour Format",
         "toggle_time_controls": "Toggle Time Controls",
         "toggle_extensions": "Toggle Extension Buttons",
         "toggle_pin": "Toggle Pin"

--- a/packages/core/src/core/calendar-validator.ts
+++ b/packages/core/src/core/calendar-validator.ts
@@ -421,7 +421,7 @@ export class CalendarValidator {
       return ['rule', 'interval', 'offset', 'month', 'extraDays'];
     }
     if (path.includes('/time')) {
-      return ['hoursInDay', 'minutesInHour', 'secondsInMinute'];
+      return ['hoursInDay', 'minutesInHour', 'secondsInMinute', 'amPmNotation'];
     }
     if (path.includes('/months/')) {
       return ['name', 'length', 'days', 'description', 'abbreviation'];

--- a/packages/core/src/core/date-formatter.ts
+++ b/packages/core/src/core/date-formatter.ts
@@ -763,7 +763,10 @@ export class DateFormatter {
           const customAm = options?.hash?.am;
           const customPm = options?.hash?.pm;
 
-          // Use custom notation if provided, otherwise use calendar notation or defaults
+          // AM/PM notation precedence chain:
+          // 1. Helper parameters (am="..." / pm="...") - highest priority
+          // 2. Calendar-level time.amPmNotation configuration
+          // 3. Default English notation ("AM"/"PM") - fallback
           const amNotation = customAm || formatter?.calendar?.time?.amPmNotation?.am || 'AM';
           const pmNotation = customPm || formatter?.calendar?.time?.amPmNotation?.pm || 'PM';
 

--- a/packages/core/src/core/date-formatter.ts
+++ b/packages/core/src/core/date-formatter.ts
@@ -717,7 +717,7 @@ export class DateFormatter {
       }
     });
 
-    // Hour helper - supports pad format
+    // Hour helper - supports pad, 12hour, 12hour-pad, and ampm formats
     Handlebars.registerHelper('ss-hour', function (this: any, ...args: any[]) {
       // Handlebars passes options as the last argument
       const options = args[args.length - 1];
@@ -734,10 +734,36 @@ export class DateFormatter {
       }
 
       const format = options?.hash?.format;
+      const calendarId = options?.data?.root?._calendarId;
+      const formatter = calendarId ? DateFormatter.helperRegistry.get(calendarId) : null;
 
       switch (format) {
         case 'pad':
           return hourValue.toString().padStart(2, '0');
+        case '12hour': {
+          // Convert 24-hour to 12-hour format
+          let hour12 = hourValue % 12;
+          if (hour12 === 0) hour12 = 12; // 0 and 12 both show as 12
+          return hour12.toString();
+        }
+        case '12hour-pad': {
+          // Convert 24-hour to 12-hour format with padding
+          let hour12 = hourValue % 12;
+          if (hour12 === 0) hour12 = 12;
+          return hour12.toString().padStart(2, '0');
+        }
+        case 'ampm': {
+          // Get am/pm notation from calendar or options
+          const customAm = options?.hash?.am;
+          const customPm = options?.hash?.pm;
+
+          // Use custom notation if provided, otherwise use calendar notation or defaults
+          const amNotation = customAm || formatter?.calendar?.time?.amPmNotation?.am || 'AM';
+          const pmNotation = customPm || formatter?.calendar?.time?.amPmNotation?.pm || 'PM';
+
+          // Hour < 12 is AM, hour >= 12 is PM
+          return hourValue < 12 ? amNotation : pmNotation;
+        }
         default:
           return hourValue.toString();
       }

--- a/packages/core/src/core/date-formatter.ts
+++ b/packages/core/src/core/date-formatter.ts
@@ -990,10 +990,9 @@ export class DateFormatter {
           const halfDay = Math.floor(hoursInDay / 2);
           const hourInHalf = h % halfDay;
           const hour12 = hourInHalf === 0 ? halfDay : hourInHalf;
-          const ampm =
-            h < halfDay
-              ? formatter.calendar.time.amPmNotation!.am
-              : formatter.calendar.time.amPmNotation!.pm;
+          // Type assertion: we know amPmNotation exists because has12HourSupport checked it
+          const amPmNotation = formatter.calendar.time.amPmNotation!;
+          const ampm = h < halfDay ? amPmNotation.am : amPmNotation.pm;
           return `${hour12}:${m.toString().padStart(2, '0')} ${ampm}`;
         }
 

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -799,6 +799,20 @@ function registerSettings(): void {
     },
   });
 
+  // === TIME FORMAT SETTINGS ===
+
+  game.settings.register('seasons-and-stars', 'prefer12HourFormat', {
+    name: 'Prefer 12-Hour Time Format',
+    hint: 'When enabled, times are displayed in 12-hour format with AM/PM notation instead of 24-hour format (e.g., "2:30 PM" instead of "14:30"). Requires calendar support for 12-hour formatting.',
+    scope: 'client',
+    config: true,
+    type: Boolean,
+    default: false,
+    onChange: () => {
+      Hooks.callAll('seasons-stars:settingsChanged', 'prefer12HourFormat');
+    },
+  });
+
   // === TIME ADVANCEMENT SETTINGS ===
 
   game.settings.register('seasons-and-stars', 'timeAdvancementRatio', {

--- a/packages/core/src/types/calendar.d.ts
+++ b/packages/core/src/types/calendar.d.ts
@@ -60,6 +60,10 @@ export interface SeasonsStarsCalendar {
     hoursInDay: number;
     minutesInHour: number;
     secondsInMinute: number;
+    amPmNotation?: {
+      am: string;
+      pm: string;
+    };
   };
 
   // Date formatting templates using Handlebars syntax

--- a/packages/core/src/types/calendar.d.ts
+++ b/packages/core/src/types/calendar.d.ts
@@ -60,6 +60,20 @@ export interface SeasonsStarsCalendar {
     hoursInDay: number;
     minutesInHour: number;
     secondsInMinute: number;
+    /**
+     * Optional am/pm notation for 12-hour time display
+     * @example
+     * // Standard English
+     * { am: "AM", pm: "PM" }
+     *
+     * @example
+     * // With periods
+     * { am: "a.m.", pm: "p.m." }
+     *
+     * @example
+     * // Japanese
+     * { am: "午前", pm: "午後" }
+     */
     amPmNotation?: {
       am: string;
       pm: string;

--- a/packages/core/src/ui/calendar-mini-widget.ts
+++ b/packages/core/src/ui/calendar-mini-widget.ts
@@ -765,6 +765,17 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
           );
           await this.render();
         },
+      },
+      {
+        name: game.i18n.localize('SEASONS_STARS.mini_widget.context_menu.toggle_12hour'),
+        icon: '<i class="fas fa-clock"></i>',
+        callback: async () => {
+          const currentValue = Boolean(
+            game.settings?.get('seasons-and-stars', 'prefer12HourFormat')
+          );
+          await game.settings?.set('seasons-and-stars', 'prefer12HourFormat', !currentValue);
+          await this.render();
+        },
       }
     );
 

--- a/packages/core/src/ui/calendar-mini-widget.ts
+++ b/packages/core/src/ui/calendar-mini-widget.ts
@@ -384,13 +384,13 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
 
     // If exact mode or no calendar, always show exact time
     if (canonicalMode === 'exact' || !calendar) {
-      return this.formatExactTime(time);
+      return this.formatExactTime(time, calendar);
     }
 
     // Check for canonical hours
     const canonicalHours = calendar.canonicalHours;
     if (!canonicalHours || canonicalHours.length === 0) {
-      return this.formatExactTime(time);
+      return this.formatExactTime(time, calendar);
     }
 
     // Look for matching canonical hour
@@ -408,13 +408,39 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
     }
 
     // Fallback to exact time for auto mode
-    return this.formatExactTime(time);
+    return this.formatExactTime(time, calendar);
   }
 
   /**
-   * Format exact time as HH:MM
+   * Format exact time as HH:MM, respecting 12-hour preference setting
    */
-  private formatExactTime(time: { hour: number; minute: number; second: number }): string {
+  private formatExactTime(
+    time: { hour: number; minute: number; second: number },
+    calendar?: import('../types/calendar').SeasonsStarsCalendar
+  ): string {
+    // Check if user prefers 12-hour format
+    const prefer12Hour =
+      typeof game !== 'undefined' &&
+      game.settings?.get('seasons-and-stars', 'prefer12HourFormat') === true;
+
+    // Check if calendar supports 12-hour format
+    const has12HourSupport =
+      calendar?.time?.amPmNotation &&
+      calendar.time.amPmNotation.am &&
+      calendar.time.amPmNotation.pm;
+
+    if (prefer12Hour && has12HourSupport) {
+      // Use 12-hour format with am/pm
+      const hoursInDay = calendar?.time?.hoursInDay || 24;
+      const halfDay = Math.floor(hoursInDay / 2);
+      const hourInHalf = time.hour % halfDay;
+      const hour12 = hourInHalf === 0 ? halfDay : hourInHalf;
+      const amPmNotation = calendar!.time!.amPmNotation!;
+      const ampm = time.hour < halfDay ? amPmNotation.am : amPmNotation.pm;
+      return `${hour12}:${time.minute.toString().padStart(2, '0')} ${ampm}`;
+    }
+
+    // Default 24-hour format
     const hour = time.hour.toString().padStart(2, '0');
     const minute = time.minute.toString().padStart(2, '0');
     return `${hour}:${minute}`;
@@ -971,7 +997,8 @@ export class CalendarMiniWidget extends foundry.applications.api.HandlebarsAppli
           settingName === 'miniWidgetShowMoonPhases' ||
           settingName === SETTINGS_KEYS.MINI_WIDGET_SHOW_SUNRISE_SUNSET ||
           settingName === 'miniWidgetShowExtensions' ||
-          settingName === 'alwaysShowQuickTimeButtons') &&
+          settingName === 'alwaysShowQuickTimeButtons' ||
+          settingName === 'prefer12HourFormat') &&
         CalendarMiniWidget.activeInstance?.rendered
       ) {
         CalendarMiniWidget.activeInstance.render();

--- a/packages/core/test/unit/core/date-formatter-12hour.test.ts
+++ b/packages/core/test/unit/core/date-formatter-12hour.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Date Formatter 12-Hour Clock Tests
+ *
+ * Tests for 12-hour clock display functionality including am/pm notation
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DateFormatter } from '../../../src/core/date-formatter';
+import { CalendarDate } from '../../../src/core/calendar-date';
+import type { SeasonsStarsCalendar } from '../../../src/types/calendar';
+
+// Use REAL Handlebars for date formatter testing
+import Handlebars from 'handlebars';
+global.Handlebars = Handlebars;
+
+describe('DateFormatter - 12-Hour Clock Support', () => {
+  let formatter: DateFormatter;
+  let mockCalendar: SeasonsStarsCalendar;
+  let mockDate: CalendarDate;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    DateFormatter.resetHelpersForTesting();
+
+    mockCalendar = {
+      id: 'test-calendar',
+      name: 'Test Calendar',
+      months: [{ name: 'January', abbreviation: 'Jan', days: 31 }],
+      weekdays: [{ name: 'Monday', abbreviation: 'Mon' }],
+      year: { prefix: '', suffix: '' },
+      time: {
+        hoursInDay: 24,
+        minutesInHour: 60,
+        secondsInMinute: 60,
+      },
+    } as SeasonsStarsCalendar;
+
+    mockDate = {
+      year: 2024,
+      month: 1,
+      day: 15,
+      weekday: 1,
+      time: { hour: 14, minute: 30, second: 0 },
+    } as CalendarDate;
+  });
+
+  describe('ss-hour helper with 12hour format', () => {
+    it('should convert 24-hour time to 12-hour format', () => {
+      formatter = new DateFormatter(mockCalendar);
+
+      // Test afternoon (14:00 → 2)
+      const result14 = formatter.format(mockDate, '{{ss-hour format="12hour"}}');
+      expect(result14).toBe('2');
+
+      // Test midnight (00:00 → 12)
+      const midnight = { ...mockDate, time: { hour: 0, minute: 0, second: 0 } };
+      const result00 = formatter.format(midnight, '{{ss-hour format="12hour"}}');
+      expect(result00).toBe('12');
+
+      // Test noon (12:00 → 12)
+      const noon = { ...mockDate, time: { hour: 12, minute: 0, second: 0 } };
+      const result12 = formatter.format(noon, '{{ss-hour format="12hour"}}');
+      expect(result12).toBe('12');
+
+      // Test 1 AM (01:00 → 1)
+      const oneAM = { ...mockDate, time: { hour: 1, minute: 0, second: 0 } };
+      const result01 = formatter.format(oneAM, '{{ss-hour format="12hour"}}');
+      expect(result01).toBe('1');
+
+      // Test 11 PM (23:00 → 11)
+      const elevenPM = { ...mockDate, time: { hour: 23, minute: 0, second: 0 } };
+      const result23 = formatter.format(elevenPM, '{{ss-hour format="12hour"}}');
+      expect(result23).toBe('11');
+    });
+
+    it('should support padded 12-hour format', () => {
+      formatter = new DateFormatter(mockCalendar);
+
+      // Test with padding (2 → 02)
+      const result = formatter.format(mockDate, '{{ss-hour format="12hour-pad"}}');
+      expect(result).toBe('02');
+
+      // Test midnight with padding (12 → 12)
+      const midnight = { ...mockDate, time: { hour: 0, minute: 0, second: 0 } };
+      const resultMidnight = formatter.format(midnight, '{{ss-hour format="12hour-pad"}}');
+      expect(resultMidnight).toBe('12');
+    });
+  });
+
+  describe('ss-hour helper with ampm format', () => {
+    it('should display AM/PM using calendar-defined notation', () => {
+      const calendarWithAmPm: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: 24,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: 'AM',
+            pm: 'PM',
+          },
+        },
+      };
+
+      formatter = new DateFormatter(calendarWithAmPm);
+
+      // Test PM (14:00 → PM)
+      const resultPM = formatter.format(mockDate, '{{ss-hour format="ampm"}}');
+      expect(resultPM).toBe('PM');
+
+      // Test AM (08:00 → AM)
+      const morning = { ...mockDate, time: { hour: 8, minute: 0, second: 0 } };
+      const resultAM = formatter.format(morning, '{{ss-hour format="ampm"}}');
+      expect(resultAM).toBe('AM');
+
+      // Test midnight (00:00 → AM)
+      const midnight = { ...mockDate, time: { hour: 0, minute: 0, second: 0 } };
+      const resultMidnight = formatter.format(midnight, '{{ss-hour format="ampm"}}');
+      expect(resultMidnight).toBe('AM');
+
+      // Test noon (12:00 → PM)
+      const noon = { ...mockDate, time: { hour: 12, minute: 0, second: 0 } };
+      const resultNoon = formatter.format(noon, '{{ss-hour format="ampm"}}');
+      expect(resultNoon).toBe('PM');
+    });
+
+    it('should use default AM/PM when calendar has no amPmNotation', () => {
+      formatter = new DateFormatter(mockCalendar);
+
+      // Should use default AM/PM
+      const resultPM = formatter.format(mockDate, '{{ss-hour format="ampm"}}');
+      expect(resultPM).toBe('PM');
+
+      const morning = { ...mockDate, time: { hour: 8, minute: 0, second: 0 } };
+      const resultAM = formatter.format(morning, '{{ss-hour format="ampm"}}');
+      expect(resultAM).toBe('AM');
+    });
+
+    it('should support custom am/pm notation via helper parameters', () => {
+      formatter = new DateFormatter(mockCalendar);
+
+      // Test custom lowercase notation
+      const resultPM = formatter.format(mockDate, '{{ss-hour format="ampm" am="a.m." pm="p.m."}}');
+      expect(resultPM).toBe('p.m.');
+
+      const morning = { ...mockDate, time: { hour: 8, minute: 0, second: 0 } };
+      const resultAM = formatter.format(morning, '{{ss-hour format="ampm" am="a.m." pm="p.m."}}');
+      expect(resultAM).toBe('a.m.');
+    });
+
+    it('should support localized am/pm notation', () => {
+      const calendarWithLocalizedAmPm: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: 24,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: '午前',
+            pm: '午後',
+          },
+        },
+      };
+
+      formatter = new DateFormatter(calendarWithLocalizedAmPm);
+
+      const resultPM = formatter.format(mockDate, '{{ss-hour format="ampm"}}');
+      expect(resultPM).toBe('午後');
+
+      const morning = { ...mockDate, time: { hour: 8, minute: 0, second: 0 } };
+      const resultAM = formatter.format(morning, '{{ss-hour format="ampm"}}');
+      expect(resultAM).toBe('午前');
+    });
+  });
+
+  describe('Complete 12-hour time formats', () => {
+    it('should format complete 12-hour time with AM/PM', () => {
+      const calendarWithAmPm: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: 24,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: 'AM',
+            pm: 'PM',
+          },
+        },
+      };
+
+      formatter = new DateFormatter(calendarWithAmPm);
+
+      // Test 2:30 PM
+      const result = formatter.format(
+        mockDate,
+        '{{ss-hour format="12hour"}}:{{ss-minute format="pad"}} {{ss-hour format="ampm"}}'
+      );
+      expect(result).toBe('2:30 PM');
+
+      // Test 8:00 AM
+      const morning = { ...mockDate, time: { hour: 8, minute: 0, second: 0 } };
+      const resultMorning = formatter.format(
+        morning,
+        '{{ss-hour format="12hour"}}:{{ss-minute format="pad"}} {{ss-hour format="ampm"}}'
+      );
+      expect(resultMorning).toBe('8:00 AM');
+
+      // Test 12:00 PM (noon)
+      const noon = { ...mockDate, time: { hour: 12, minute: 0, second: 0 } };
+      const resultNoon = formatter.format(
+        noon,
+        '{{ss-hour format="12hour"}}:{{ss-minute format="pad"}} {{ss-hour format="ampm"}}'
+      );
+      expect(resultNoon).toBe('12:00 PM');
+
+      // Test 12:00 AM (midnight)
+      const midnight = { ...mockDate, time: { hour: 0, minute: 0, second: 0 } };
+      const resultMidnight = formatter.format(
+        midnight,
+        '{{ss-hour format="12hour"}}:{{ss-minute format="pad"}} {{ss-hour format="ampm"}}'
+      );
+      expect(resultMidnight).toBe('12:00 AM');
+    });
+
+    it('should format 12-hour time with padded hour', () => {
+      const calendarWithAmPm: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: 24,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: 'AM',
+            pm: 'PM',
+          },
+        },
+      };
+
+      formatter = new DateFormatter(calendarWithAmPm);
+
+      // Test 02:30 PM (padded)
+      const result = formatter.format(
+        mockDate,
+        '{{ss-hour format="12hour-pad"}}:{{ss-minute format="pad"}} {{ss-hour format="ampm"}}'
+      );
+      expect(result).toBe('02:30 PM');
+    });
+
+    it('should work with custom am/pm override in complete formats', () => {
+      formatter = new DateFormatter(mockCalendar);
+
+      const result = formatter.format(
+        mockDate,
+        '{{ss-hour format="12hour"}}:{{ss-minute format="pad"}} {{ss-hour format="ampm" am="a.m." pm="p.m."}}'
+      );
+      expect(result).toBe('2:30 p.m.');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('should handle undefined or null hour gracefully', () => {
+      const dateWithoutTime = {
+        ...mockDate,
+        time: undefined,
+      } as CalendarDate;
+
+      formatter = new DateFormatter(mockCalendar);
+
+      // Should default to 0 (midnight) which converts to 12 AM
+      const result = formatter.format(dateWithoutTime, '{{ss-hour format="12hour"}}');
+      expect(result).toBe('12');
+
+      const resultAmPm = formatter.format(dateWithoutTime, '{{ss-hour format="ampm"}}');
+      expect(resultAmPm).toBe('AM');
+    });
+
+    it('should handle hours >= 24 gracefully', () => {
+      const invalidDate = { ...mockDate, time: { hour: 25, minute: 0, second: 0 } };
+      formatter = new DateFormatter(mockCalendar);
+
+      // Should handle modulo operation (25 % 12 after conversion)
+      const result = formatter.format(invalidDate, '{{ss-hour format="12hour"}}');
+      expect(result).toBe('1'); // 25 % 24 = 1, 1 in 12-hour = 1 AM
+    });
+
+    it('should handle negative hours gracefully', () => {
+      const invalidDate = { ...mockDate, time: { hour: -1, minute: 0, second: 0 } };
+      formatter = new DateFormatter(mockCalendar);
+
+      // Should handle negative values literally (no normalization)
+      // Negative hours are invalid input, so we just pass through the calculation
+      const result = formatter.format(invalidDate, '{{ss-hour format="12hour"}}');
+      // -1 % 12 = -1 in JavaScript, which is treated as -1
+      // Since it's not 0, it doesn't get converted to 12
+      expect(result).toBe('-1');
+    });
+  });
+
+  describe('Calendar dateFormats integration', () => {
+    it('should support 12-hour formats in calendar dateFormats', () => {
+      const calendarWith12HourFormats: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: 24,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: 'AM',
+            pm: 'PM',
+          },
+        },
+        dateFormats: {
+          time12:
+            '{{ss-hour format="12hour"}}:{{ss-minute format="pad"}} {{ss-hour format="ampm"}}',
+          datetime12:
+            '{{ss-month format="abbr"}} {{day}}, {{year}} {{ss-hour format="12hour"}}:{{ss-minute format="pad"}} {{ss-hour format="ampm"}}',
+        },
+      };
+
+      formatter = new DateFormatter(calendarWith12HourFormats);
+
+      const time = formatter.formatNamed(mockDate, 'time12');
+      expect(time).toBe('2:30 PM');
+
+      const datetime = formatter.formatNamed(mockDate, 'datetime12');
+      expect(datetime).toBe('Jan 15, 2024 2:30 PM');
+    });
+  });
+});

--- a/packages/core/test/unit/core/date-formatter-12hour.test.ts
+++ b/packages/core/test/unit/core/date-formatter-12hour.test.ts
@@ -326,4 +326,234 @@ describe('DateFormatter - 12-Hour Clock Support', () => {
       expect(datetime).toBe('Jan 15, 2024 2:30 PM');
     });
   });
+
+  describe('Non-24-Hour Calendars', () => {
+    it('should handle 20-hour days correctly', () => {
+      const calendar20Hour: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: 20,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: 'AM',
+            pm: 'PM',
+          },
+        },
+      };
+
+      formatter = new DateFormatter(calendar20Hour);
+
+      // Hour 0 - start of day (midnight equivalent) → should be 10 AM (first half)
+      const midnight = { ...mockDate, time: { hour: 0, minute: 0, second: 0 } };
+      expect(formatter.format(midnight, '{{ss-hour format="12hour"}}')).toBe('10');
+      expect(formatter.format(midnight, '{{ss-hour format="ampm"}}')).toBe('AM');
+
+      // Hour 5 - 25% through day → should be 5 AM (before midday)
+      const hour5 = { ...mockDate, time: { hour: 5, minute: 0, second: 0 } };
+      expect(formatter.format(hour5, '{{ss-hour format="12hour"}}')).toBe('5');
+      expect(formatter.format(hour5, '{{ss-hour format="ampm"}}')).toBe('AM');
+
+      // Hour 9 - just before midday → should be 9 AM (last hour before noon)
+      const hour9 = { ...mockDate, time: { hour: 9, minute: 0, second: 0 } };
+      expect(formatter.format(hour9, '{{ss-hour format="12hour"}}')).toBe('9');
+      expect(formatter.format(hour9, '{{ss-hour format="ampm"}}')).toBe('AM');
+
+      // Hour 10 - midday (50% through 20-hour day) → should be 10 PM (second half starts)
+      const midday = { ...mockDate, time: { hour: 10, minute: 0, second: 0 } };
+      expect(formatter.format(midday, '{{ss-hour format="12hour"}}')).toBe('10');
+      expect(formatter.format(midday, '{{ss-hour format="ampm"}}')).toBe('PM');
+
+      // Hour 14 - 70% through day → should be 4 PM (second half)
+      const hour14 = { ...mockDate, time: { hour: 14, minute: 0, second: 0 } };
+      expect(formatter.format(hour14, '{{ss-hour format="12hour"}}')).toBe('4');
+      expect(formatter.format(hour14, '{{ss-hour format="ampm"}}')).toBe('PM');
+
+      // Hour 19 - last hour of day → should be 9 PM
+      const hour19 = { ...mockDate, time: { hour: 19, minute: 0, second: 0 } };
+      expect(formatter.format(hour19, '{{ss-hour format="12hour"}}')).toBe('9');
+      expect(formatter.format(hour19, '{{ss-hour format="ampm"}}')).toBe('PM');
+    });
+
+    it('should handle 30-hour days correctly', () => {
+      const calendar30Hour: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: 30,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: 'AM',
+            pm: 'PM',
+          },
+        },
+      };
+
+      formatter = new DateFormatter(calendar30Hour);
+
+      // Hour 0 - start of day → should be 15 AM (using 15 as "half")
+      const midnight = { ...mockDate, time: { hour: 0, minute: 0, second: 0 } };
+      expect(formatter.format(midnight, '{{ss-hour format="12hour"}}')).toBe('15');
+      expect(formatter.format(midnight, '{{ss-hour format="ampm"}}')).toBe('AM');
+
+      // Hour 7 - 7/30 through day → should be 7 AM
+      const hour7 = { ...mockDate, time: { hour: 7, minute: 0, second: 0 } };
+      expect(formatter.format(hour7, '{{ss-hour format="12hour"}}')).toBe('7');
+      expect(formatter.format(hour7, '{{ss-hour format="ampm"}}')).toBe('AM');
+
+      // Hour 14 - just before midday → should be 14 AM
+      const hour14 = { ...mockDate, time: { hour: 14, minute: 0, second: 0 } };
+      expect(formatter.format(hour14, '{{ss-hour format="12hour"}}')).toBe('14');
+      expect(formatter.format(hour14, '{{ss-hour format="ampm"}}')).toBe('AM');
+
+      // Hour 15 - midday (50% through 30-hour day) → should be 15 PM
+      const midday = { ...mockDate, time: { hour: 15, minute: 0, second: 0 } };
+      expect(formatter.format(midday, '{{ss-hour format="12hour"}}')).toBe('15');
+      expect(formatter.format(midday, '{{ss-hour format="ampm"}}')).toBe('PM');
+
+      // Hour 22 - 22/30 through day → should be 7 PM
+      const hour22 = { ...mockDate, time: { hour: 22, minute: 0, second: 0 } };
+      expect(formatter.format(hour22, '{{ss-hour format="12hour"}}')).toBe('7');
+      expect(formatter.format(hour22, '{{ss-hour format="ampm"}}')).toBe('PM');
+
+      // Hour 29 - last hour of day → should be 14 PM
+      const hour29 = { ...mockDate, time: { hour: 29, minute: 0, second: 0 } };
+      expect(formatter.format(hour29, '{{ss-hour format="12hour"}}')).toBe('14');
+      expect(formatter.format(hour29, '{{ss-hour format="ampm"}}')).toBe('PM');
+    });
+
+    it('should handle 18-hour days correctly', () => {
+      const calendar18Hour: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: 18,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: 'AM',
+            pm: 'PM',
+          },
+        },
+      };
+
+      formatter = new DateFormatter(calendar18Hour);
+
+      // Hour 0 - start of day → should be 9 AM
+      const midnight = { ...mockDate, time: { hour: 0, minute: 0, second: 0 } };
+      expect(formatter.format(midnight, '{{ss-hour format="12hour"}}')).toBe('9');
+      expect(formatter.format(midnight, '{{ss-hour format="ampm"}}')).toBe('AM');
+
+      // Hour 4 - before midday → should be 4 AM
+      const hour4 = { ...mockDate, time: { hour: 4, minute: 0, second: 0 } };
+      expect(formatter.format(hour4, '{{ss-hour format="12hour"}}')).toBe('4');
+      expect(formatter.format(hour4, '{{ss-hour format="ampm"}}')).toBe('AM');
+
+      // Hour 9 - midday (50% through 18-hour day) → should be 9 PM
+      const midday = { ...mockDate, time: { hour: 9, minute: 0, second: 0 } };
+      expect(formatter.format(midday, '{{ss-hour format="12hour"}}')).toBe('9');
+      expect(formatter.format(midday, '{{ss-hour format="ampm"}}')).toBe('PM');
+
+      // Hour 13 - after midday → should be 4 PM (13 % 9 = 4)
+      const hour13 = { ...mockDate, time: { hour: 13, minute: 0, second: 0 } };
+      expect(formatter.format(hour13, '{{ss-hour format="12hour"}}')).toBe('4');
+      expect(formatter.format(hour13, '{{ss-hour format="ampm"}}')).toBe('PM');
+
+      // Hour 17 - last hour of day → should be 8 PM (17 % 9 = 8)
+      const hour17 = { ...mockDate, time: { hour: 17, minute: 0, second: 0 } };
+      expect(formatter.format(hour17, '{{ss-hour format="12hour"}}')).toBe('8');
+      expect(formatter.format(hour17, '{{ss-hour format="ampm"}}')).toBe('PM');
+    });
+
+    it('should handle 36-hour days correctly', () => {
+      const calendar36Hour: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: 36,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: 'AM',
+            pm: 'PM',
+          },
+        },
+      };
+
+      formatter = new DateFormatter(calendar36Hour);
+
+      // Hour 0 - start of day → should be 18 AM (36/2 = 18 hours per half)
+      const midnight = { ...mockDate, time: { hour: 0, minute: 0, second: 0 } };
+      expect(formatter.format(midnight, '{{ss-hour format="12hour"}}')).toBe('18');
+      expect(formatter.format(midnight, '{{ss-hour format="ampm"}}')).toBe('AM');
+
+      // Hour 12 - 12/36 through day → should be 12 AM (12 % 18 = 12)
+      const hour12 = { ...mockDate, time: { hour: 12, minute: 0, second: 0 } };
+      expect(formatter.format(hour12, '{{ss-hour format="12hour"}}')).toBe('12');
+      expect(formatter.format(hour12, '{{ss-hour format="ampm"}}')).toBe('AM');
+
+      // Hour 18 - midday (50% through 36-hour day) → should be 18 PM
+      const midday = { ...mockDate, time: { hour: 18, minute: 0, second: 0 } };
+      expect(formatter.format(midday, '{{ss-hour format="12hour"}}')).toBe('18');
+      expect(formatter.format(midday, '{{ss-hour format="ampm"}}')).toBe('PM');
+
+      // Hour 30 - 30/36 through day → should be 12 PM (30 % 18 = 12)
+      const hour30 = { ...mockDate, time: { hour: 30, minute: 0, second: 0 } };
+      expect(formatter.format(hour30, '{{ss-hour format="12hour"}}')).toBe('12');
+      expect(formatter.format(hour30, '{{ss-hour format="ampm"}}')).toBe('PM');
+    });
+
+    it('should handle complete 12-hour time format with non-24-hour days', () => {
+      const calendar20Hour: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: 20,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: 'AM',
+            pm: 'PM',
+          },
+        },
+      };
+
+      formatter = new DateFormatter(calendar20Hour);
+
+      // Hour 5:30 in a 20-hour day (before midday at hour 10)
+      const morning = { ...mockDate, time: { hour: 5, minute: 30, second: 0 } };
+      const resultMorning = formatter.format(
+        morning,
+        '{{ss-hour format="12hour"}}:{{ss-minute format="pad"}} {{ss-hour format="ampm"}}'
+      );
+      expect(resultMorning).toBe('5:30 AM');
+
+      // Hour 14:45 in a 20-hour day (after midday at hour 10)
+      const afternoon = { ...mockDate, time: { hour: 14, minute: 45, second: 0 } };
+      const resultAfternoon = formatter.format(
+        afternoon,
+        '{{ss-hour format="12hour"}}:{{ss-minute format="pad"}} {{ss-hour format="ampm"}}'
+      );
+      expect(resultAfternoon).toBe('4:45 PM');
+    });
+
+    it('should fallback to 24-hour logic when hoursInDay is undefined', () => {
+      const calendarWithoutHours: SeasonsStarsCalendar = {
+        ...mockCalendar,
+        time: {
+          hoursInDay: undefined as any,
+          minutesInHour: 60,
+          secondsInMinute: 60,
+          amPmNotation: {
+            am: 'AM',
+            pm: 'PM',
+          },
+        },
+      };
+
+      formatter = new DateFormatter(calendarWithoutHours);
+
+      // Should fallback to standard 24-hour logic
+      const afternoon = { ...mockDate, time: { hour: 14, minute: 30, second: 0 } };
+      expect(formatter.format(afternoon, '{{ss-hour format="12hour"}}')).toBe('2');
+      expect(formatter.format(afternoon, '{{ss-hour format="ampm"}}')).toBe('PM');
+    });
+  });
 });

--- a/packages/fantasy-pack/calendars/brithini.json
+++ b/packages/fantasy-pack/calendars/brithini.json
@@ -52,6 +52,10 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   }
 }

--- a/packages/fantasy-pack/calendars/dara-happan.json
+++ b/packages/fantasy-pack/calendars/dara-happan.json
@@ -64,6 +64,10 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   }
 }

--- a/packages/fantasy-pack/calendars/dark-sun.json
+++ b/packages/fantasy-pack/calendars/dark-sun.json
@@ -398,7 +398,11 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "dateFormats": {

--- a/packages/fantasy-pack/calendars/dnd5e-sword-coast.json
+++ b/packages/fantasy-pack/calendars/dnd5e-sword-coast.json
@@ -225,7 +225,11 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "dateFormats": {

--- a/packages/fantasy-pack/calendars/eberron.json
+++ b/packages/fantasy-pack/calendars/eberron.json
@@ -139,7 +139,11 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "dateFormats": {

--- a/packages/fantasy-pack/calendars/exandrian.json
+++ b/packages/fantasy-pack/calendars/exandrian.json
@@ -133,7 +133,11 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "moons": [

--- a/packages/fantasy-pack/calendars/forbidden-lands.json
+++ b/packages/fantasy-pack/calendars/forbidden-lands.json
@@ -177,6 +177,10 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   }
 }

--- a/packages/fantasy-pack/calendars/forgotten-realms.json
+++ b/packages/fantasy-pack/calendars/forgotten-realms.json
@@ -256,7 +256,11 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "dateFormats": {

--- a/packages/fantasy-pack/calendars/greyhawk.json
+++ b/packages/fantasy-pack/calendars/greyhawk.json
@@ -217,7 +217,11 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "dateFormats": {

--- a/packages/fantasy-pack/calendars/lunar.json
+++ b/packages/fantasy-pack/calendars/lunar.json
@@ -42,6 +42,10 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   }
 }

--- a/packages/fantasy-pack/calendars/mystaran.json
+++ b/packages/fantasy-pack/calendars/mystaran.json
@@ -170,6 +170,10 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   }
 }

--- a/packages/fantasy-pack/calendars/orlanthi.json
+++ b/packages/fantasy-pack/calendars/orlanthi.json
@@ -89,6 +89,10 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   }
 }

--- a/packages/fantasy-pack/calendars/pamaltelan.json
+++ b/packages/fantasy-pack/calendars/pamaltelan.json
@@ -45,6 +45,10 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   }
 }

--- a/packages/fantasy-pack/calendars/roshar.json
+++ b/packages/fantasy-pack/calendars/roshar.json
@@ -141,7 +141,11 @@
   "time": {
     "hoursInDay": 20,
     "minutesInHour": 50,
-    "secondsInMinute": 100
+    "secondsInMinute": 100,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "dateFormats": {

--- a/packages/fantasy-pack/calendars/symbaroum.json
+++ b/packages/fantasy-pack/calendars/symbaroum.json
@@ -194,6 +194,10 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   }
 }

--- a/packages/fantasy-pack/calendars/traditional-fantasy-epoch.json
+++ b/packages/fantasy-pack/calendars/traditional-fantasy-epoch.json
@@ -203,7 +203,11 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "dateFormats": {

--- a/packages/fantasy-pack/calendars/vale-reckoning.json
+++ b/packages/fantasy-pack/calendars/vale-reckoning.json
@@ -382,7 +382,11 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "dateFormats": {

--- a/packages/fantasy-pack/calendars/warhammer.json
+++ b/packages/fantasy-pack/calendars/warhammer.json
@@ -236,7 +236,11 @@
   "time": {
     "hoursInDay": 24,
     "minutesInHour": 60,
-    "secondsInMinute": 60
+    "secondsInMinute": 60,
+    "amPmNotation": {
+      "am": "AM",
+      "pm": "PM"
+    }
   },
 
   "seasons": [

--- a/shared/schemas/calendar-v1.0.0.json
+++ b/shared/schemas/calendar-v1.0.0.json
@@ -362,6 +362,26 @@
           "minimum": 1,
           "maximum": 120,
           "description": "Number of seconds in a minute"
+        },
+        "amPmNotation": {
+          "type": "object",
+          "required": ["am", "pm"],
+          "additionalProperties": false,
+          "properties": {
+            "am": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10,
+              "description": "Text to display for ante meridiem (before noon)"
+            },
+            "pm": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 10,
+              "description": "Text to display for post meridiem (after noon)"
+            }
+          },
+          "description": "Optional AM/PM notation for 12-hour time display"
         }
       }
     },


### PR DESCRIPTION
Closes #499

This PR adds comprehensive 12-hour clock support to the date formatting system.

## Changes

- Add optional `amPmNotation` to calendar time configuration
- Extend `ss-hour` helper to support `12hour`, `12hour-pad`, and `ampm` formats
- Support calendar-defined am/pm notation (e.g., AM/PM, a.m./p.m., or localized)
- Allow format string override via helper parameters
- Add comprehensive test coverage (13 tests)

## Usage

Calendar authors can now add 12-hour time formats:

```json
{
  "time": {
    "amPmNotation": { "am": "AM", "pm": "PM" }
  },
  "dateFormats": {
    "time12": "{{ss-hour format=\"12hour\"}}:{{ss-minute format=\"pad\"}} {{ss-hour format=\"ampm\"}}"
  }
}
```

This displays times like "2:30 PM" instead of "14:30".

🤖 Generated with [Claude Code](https://claude.ai/code)