### PR TITLE
fix: use FilePicker.implementation for Forge compatibility

### DIFF
--- a/packages/core/src/ui/calendar-selection-dialog.ts
+++ b/packages/core/src/ui/calendar-selection-dialog.ts
@@ -832,7 +832,7 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
     // Otherwise, open the file picker dialog
     try {
       // @ts-expect-error - FilePicker is available at runtime but TypeScript types may not reflect the full structure
-      const filePicker = new foundry.applications.apps.FilePicker({
+      const filePicker = new foundry.applications.apps.FilePicker.implementation({
         type: 'data',
         extensions: ['.json'],
         callback: async (path: string): Promise<void> => {

--- a/packages/custom-calendar-builder/src/calendar-builder-app.ts
+++ b/packages/custom-calendar-builder/src/calendar-builder-app.ts
@@ -611,7 +611,7 @@ export class CalendarBuilderApp extends foundry.applications.api.HandlebarsAppli
   async _onOpenCalendar(_event: Event, _target: HTMLElement): Promise<void> {
     try {
       // Check if FilePicker is available
-      const FoundryFilePicker = (foundry as any)?.applications?.apps?.FilePicker;
+      const FoundryFilePicker = (foundry as any)?.applications?.apps?.FilePicker?.implementation;
       if (!FoundryFilePicker) {
         this._notify('File picker not available in this Foundry version', 'error');
         return;


### PR DESCRIPTION
Update file picker usage to use FilePicker.implementation instead of FilePicker directly to support Forge's custom file picker implementation.

Fixes #502

Generated with [Claude Code](https://claude.ai/code)