### PR TITLE
feat: redesign calendar selection dialog with master-detail layout

### DIFF
--- a/packages/core/languages/en.json
+++ b/packages/core/languages/en.json
@@ -25,6 +25,8 @@
         "cancel": "Keep Current",
         "switch_to": "Switch to {calendar}",
         "current": "Currently Active",
+        "selected": "Selected",
+        "select_this": "Select This Calendar",
         "sample": "Sample",
         "preview": "Preview",
         "preview_tooltip": "View calendar details and sample dates",
@@ -43,7 +45,18 @@
         "file_loaded": "Custom calendar file is loaded and ready to use",
         "file_path": "File Path",
         "status": "Status",
-        "click_to_select": "Click to select a calendar file"
+        "click_to_select": "Click to select a calendar file",
+        "use_this_file": "Use This File",
+        "search_placeholder": "Search calendars...",
+        "filter_by_tag": "Filter by tag",
+        "clear_filters": "Clear filters",
+        "of": "of",
+        "no_results": "No calendars match your search",
+        "select_to_view": "Select a calendar to view details",
+        "toggle_variants": "Toggle variants",
+        "tags": "Tags",
+        "prev_month": "Previous month",
+        "next_month": "Next month"
       },
       "calendar_preview": {
         "title": "Calendar Preview: {calendar}"

--- a/packages/core/src/styles/calendar-selection-dialog.scss
+++ b/packages/core/src/styles/calendar-selection-dialog.scss
@@ -1,646 +1,710 @@
 /**
- * Calendar Selection Dialog - Native Foundry Integration
+ * Calendar Selection Dialog - Master-Detail Layout
  */
 
 .seasons-stars.calendar-selection-dialog {
-  // Use native Foundry CSS Grid system with scrolling
-  .calendar-selection-grid {
+  // Main container uses CSS Grid for master-detail layout
+  .window-content {
     display: grid;
-    grid-template-columns: 1fr; // Single column for wider cards
-    gap: 1.25rem;
-    min-height: 300px;
-    max-height: 520px;
-    overflow-y: auto;
-    overflow-x: hidden;
-    padding: 0.5rem 0.75rem 0.5rem 0.5rem; // Better padding with scrollbar space
-    
-    // Ensure smooth scrolling
-    scroll-behavior: smooth;
-    
-    // Enhanced scrollbar styling for Foundry
-    &::-webkit-scrollbar {
-      width: 8px;
-    }
-    
-    &::-webkit-scrollbar-track {
-      background: var(--color-bg-alt);
-      border-radius: 4px;
-      margin: 4px 0;
-    }
-    
-    &::-webkit-scrollbar-thumb {
-      background: linear-gradient(180deg, var(--color-border-light-secondary), var(--color-border-light-tertiary));
-      border-radius: 4px;
-      border: 1px solid var(--color-bg-alt);
-      
-      &:hover {
-        background: linear-gradient(180deg, var(--color-border-light-primary), var(--color-border-light-secondary));
+    grid-template-rows: auto 1fr auto auto;
+    grid-template-columns: 35% 65%;
+    gap: 0;
+    height: 100%;
+    padding: 0;
+  }
+
+  // ===== SEARCH HEADER =====
+  .calendar-search-header {
+    grid-column: 1 / -1;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: var(--color-bg-secondary);
+    border-bottom: 1px solid var(--color-border-light-tertiary);
+
+    .search-input-container {
+      flex: 1;
+      position: relative;
+      display: flex;
+      align-items: center;
+
+      > i {
+        position: absolute;
+        left: 0.75rem;
+        color: var(--color-text-light-6);
+        pointer-events: none;
       }
-      
-      &:active {
-        background: var(--color-warm-3);
+
+      .calendar-search-input {
+        width: 100%;
+        padding: 0.5rem 0.75rem 0.5rem 2rem;
+        border: 1px solid var(--color-border-light-secondary);
+        border-radius: 4px;
+        background: var(--color-bg-option);
+        color: var(--color-text-light-primary);
+        font-size: 0.9rem;
+
+        &:focus {
+          outline: none;
+          border-color: var(--color-warm-2);
+          box-shadow: 0 0 4px var(--color-warm-2);
+        }
+
+        &::placeholder {
+          color: var(--color-text-light-6);
+        }
+      }
+
+      .clear-filters-btn {
+        position: absolute;
+        right: 0.5rem;
+        background: none;
+        border: none;
+        color: var(--color-text-light-6);
+        cursor: pointer;
+        padding: 0.25rem;
+
+        &:hover {
+          color: var(--color-warm-1);
+        }
       }
     }
-    
-    // Add subtle fade effect at top/bottom when scrolling
-    &::before, &::after {
-      content: '';
-      position: sticky;
-      display: block;
-      height: 8px;
-      margin: 0 -0.5rem;
-      z-index: 1;
-      pointer-events: none;
+
+    .tag-filter-container {
+      .tag-filter {
+        min-width: 120px;
+        padding: 0.375rem;
+        border: 1px solid var(--color-border-light-secondary);
+        border-radius: 4px;
+        background: var(--color-bg-option);
+        color: var(--color-text-light-primary);
+        font-size: 0.85rem;
+      }
     }
-    
-    &::before {
-      top: 0;
-      background: linear-gradient(to bottom, var(--color-bg-option), transparent);
-    }
-    
-    &::after {
-      bottom: 0;
-      background: linear-gradient(to top, var(--color-bg-option), transparent);
+
+    .result-count {
+      font-size: 0.85rem;
+      color: var(--color-text-light-6);
+      white-space: nowrap;
     }
   }
 
-  // Calendar cards using native ui-control pattern
-  .calendar-card {
-    // Extend Foundry's ui-control base styling
-    padding: 1.25rem;
-    border-radius: 6px;
-    min-height: 220px;
-    cursor: var(--cursor-pointer, pointer);
-    width: 100%; // Ensure cards use full available width
-    position: relative;
+  // ===== LIST PANE (LEFT) =====
+  .calendar-list-pane {
+    grid-row: 2;
+    grid-column: 1;
+    border-right: 1px solid var(--color-border-light-tertiary);
     overflow: hidden;
-    
-    // Use Foundry's interactive colors with enhanced gradients
-    border: 1px solid var(--color-border-light-tertiary);
-    background: linear-gradient(145deg, var(--color-bg-option), var(--color-bg-alt));
-    transition: all 0.3s ease;
-    
-    // Add subtle inner shadow for depth
-    box-shadow: 
-      inset 0 1px 0 rgba(255, 255, 255, 0.1),
-      0 2px 4px rgba(0, 0, 0, 0.1);
+    display: flex;
+    flex-direction: column;
 
-    // Enhanced Foundry hover effect
-    &:hover {
-      text-shadow: 0 0 8px var(--color-shadow-primary);
-      border-color: var(--color-warm-2);
-      background: linear-gradient(145deg, var(--color-bg-primary), var(--color-bg-option));
-      box-shadow: 
-        inset 0 1px 0 rgba(255, 255, 255, 0.15),
-        0 4px 12px rgba(0, 0, 0, 0.15),
-        0 0 8px var(--color-shadow-primary);
-      transform: translateY(-2px);
-    }
-
-    // Enhanced active state
-    &.active {
-      background: linear-gradient(145deg, var(--color-bg-primary), var(--color-warm-5));
-      border-color: var(--color-warm-2);
-      box-shadow: 
-        inset 0 1px 0 rgba(255, 255, 255, 0.2),
-        0 0 12px var(--color-warm-1);
-      
-      &::before {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: 0;
-        right: 0;
-        height: 3px;
-        background: linear-gradient(90deg, var(--color-warm-1), var(--color-warm-2), var(--color-warm-1));
-        z-index: 1;
-      }
-    }
-
-    // Enhanced picked/selected state
-    &.picked {
-      outline: 2px solid var(--color-warm-1);
-      outline-offset: -1px;
-      box-shadow: 
-        inset 0 1px 0 rgba(255, 255, 255, 0.2),
-        0 0 16px var(--color-warm-1),
-        inset 0 0 20px rgba(255, 200, 100, 0.1);
-      background: linear-gradient(145deg, var(--color-bg-primary), var(--color-warm-5));
-      border-color: var(--color-warm-1);
-      
-      &::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        right: 0;
-        width: 0;
-        height: 0;
-        border-top: 24px solid var(--color-warm-1);
-        border-left: 24px solid transparent;
-        z-index: 2;
-      }
-      
-      // Add checkmark in corner
-      &::before {
-        content: '✓';
-        position: absolute;
-        top: 4px;
-        right: 6px;
-        color: white;
-        font-size: 12px;
-        font-weight: bold;
-        z-index: 3;
-      }
-    }
-    
-    // Variant calendar cards have a subtle visual distinction
-    &.variant {
-      border-left: 3px solid var(--color-cool-2);
-      margin-left: 1rem;
-      
-      // No connecting line - just indentation and border
-      
-      &:hover {
-        border-left-color: var(--color-cool-1);
-      }
-      
-      &.picked {
-        border-left-color: var(--color-warm-1);
-      }
-      
-      .calendar-name .variant-indicator i {
-        transform: rotate(45deg);
-      }
-    }
-
-    // Hierarchical indentation for variants
-    &.hierarchy-level-1 {
-      margin-left: 1.5rem;
-      border-left: 2px solid var(--color-cool-3);
-      
-      // No connecting line - just indentation and border
-      
-      .calendar-name {
-        font-size: 1rem; // Slightly smaller for hierarchy
-        
-        .variant-indicator {
-          color: var(--color-cool-2);
-          opacity: 0.9;
-        }
-      }
-      
-      &:hover {
-        border-left-color: var(--color-cool-2);
-      }
-      
-      &.picked {
-        border-left-color: var(--color-warm-2);
-      }
-    }
-
-    .card-header {
-      margin-bottom: 0.5rem;
-      gap: 0.5rem;
-
-      .calendar-title-row {
-        align-items: flex-start;
-        gap: 0.5rem;
-
-        .calendar-title-info {
-          flex: 1;
-          min-width: 0;
-
-          .calendar-name {
-            margin: 0 0 0.25rem 0;
-            font-size: 1.1rem;
-            font-weight: 600;
-            color: var(--color-text-light-primary);
-            display: flex;
-            align-items: center;
-            gap: 0.5rem;
-            
-            .variant-indicator {
-              color: var(--color-cool-1);
-              font-size: 0.9rem;
-              opacity: 0.8;
-              
-              i {
-                transform: rotate(0deg);
-                transition: transform 0.2s ease;
-              }
-            }
-          }
-
-          .calendar-setting {
-            font-size: 0.8rem;
-            color: var(--color-text-light-7);
-            font-style: italic;
-          }
-          
-          .variant-info {
-            font-size: 0.75rem;
-            color: var(--color-cool-2);
-            font-weight: 500;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            background: var(--color-bg-secondary);
-            padding: 0.125rem 0.375rem;
-            border-radius: 3px;
-            border: 1px solid var(--color-cool-5);
-            margin-top: 0.25rem;
-            display: inline-block;
-          }
-        }
-
-        .calendar-badges {
-          flex-shrink: 0;
-          align-items: center;
-          gap: 0.375rem;
-
-          .current-badge {
-            color: var(--color-warm-1);
-            font-size: 1.2rem;
-            filter: drop-shadow(0 0 4px var(--color-warm-1));
-            animation: current-star-glow 3s ease-in-out infinite alternate;
-            
-            i {
-              transform-origin: center;
-            }
-          }
-
-          .module-badge {
-            padding: 0.25rem 0.5rem;
-            border-radius: 12px;
-            font-size: 0.7rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-            pointer-events: none; // Make it non-interactive
-            
-            // Default (dark theme) styling
-            background: linear-gradient(135deg, var(--color-cool-2), var(--color-cool-1));
-            color: var(--color-text-light-primary);
-            border: 1px solid var(--color-cool-3);
-            
-            i {
-              margin-right: 0.25rem;
-              font-size: 0.8rem;
-            }
-            
-            // Add "MODULE" text after icon for clarity
-            &::after {
-              content: 'MODULE';
-            }
-          }
-
-          .external-badge {
-            padding: 0.25rem 0.5rem;
-            border-radius: 12px;
-            font-size: 0.7rem;
-            font-weight: 700;
-            text-transform: uppercase;
-            letter-spacing: 0.5px;
-            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-            pointer-events: none; // Make it non-interactive
-            
-            // Default (dark theme) styling
-            background: linear-gradient(135deg, var(--color-border-light-secondary), var(--color-border-light-tertiary));
-            color: var(--color-text-light-primary);
-            border: 1px solid var(--color-border-light-primary);
-            
-            i {
-              margin-right: 0.25rem;
-              font-size: 0.8rem;
-            }
-            
-            // Add "EXTERNAL" text after icon for clarity
-            &::after {
-              content: 'EXTERNAL';
-            }
-          }
-        }
-      }
-      
-      .source-info {
-        align-items: center;
-        gap: 0.625rem;
-        width: 100%; // Take full width now that it's on its own row
-        background: rgba(0, 0, 0, 0.1);
-        padding: 0.5rem 0.75rem;
-        border-radius: 4px;
-        margin-top: 0.5rem;
-        border: 1px solid rgba(255, 255, 255, 0.05);
-        
-        .source-icon {
-          font-size: 0.9rem;
-          color: var(--color-text-light-5);
-          flex-shrink: 0;
-          width: 1.1rem;
-          text-align: center;
-        }
-        
-        .source-label {
-          font-size: 0.85rem;
-          color: var(--color-text-light-5);
-          font-weight: 600;
-          word-break: break-word;
-          line-height: 1.3;
-          flex: 1;
-          text-transform: uppercase;
-          letter-spacing: 0.3px;
-        }
-      }
-    }
-
-    .card-content {
+    .calendar-list-container {
       flex: 1;
-      gap: 0.75rem;
+      overflow-y: auto;
+      padding: 0.5rem;
 
-      .calendar-description {
-        font-size: 0.9rem;
-        line-height: 1.4;
-        margin: 0;
-        color: var(--color-text-light-6);
+      &:focus {
+        outline: none;
       }
 
-      .preview-section {
-        margin-top: auto;
-        
-        .sample-preview, 
-        .mini-preview {
-          background: linear-gradient(145deg, var(--color-bg-secondary), var(--color-bg-alt));
-          border: 1px solid var(--color-border-light-tertiary);
-          border-radius: 5px;
-          padding: 0.75rem;
-          margin-bottom: 0.75rem;
-          box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.1);
-          transition: all 0.2s ease;
-          
-          &:hover {
-            background: linear-gradient(145deg, var(--color-bg-alt), var(--color-bg-secondary));
-            border-color: var(--color-border-light-secondary);
-            box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.15);
-          }
+      // Custom scrollbar
+      &::-webkit-scrollbar {
+        width: 6px;
+      }
 
-          label {
-            font-size: 0.7rem;
-            font-weight: 700;
-            color: var(--color-text-light-6);
-            text-transform: uppercase;
-            letter-spacing: 0.8px;
-            margin-bottom: 0.375rem;
-            display: flex;
-            align-items: center;
-            gap: 0.25rem;
-            
-            &::before {
-              content: '◆';
-              font-size: 0.6rem;
-              color: var(--color-cool-2);
-            }
-          }
+      &::-webkit-scrollbar-track {
+        background: var(--color-bg-alt);
+      }
 
-          .sample-date,
-          .mini-format {
-            font-family: var(--font-mono);
-            font-size: 0.9rem;
-            color: var(--color-text-light-primary);
-            font-weight: 600;
-            line-height: 1.3;
-            background: rgba(0, 0, 0, 0.1);
-            padding: 0.25rem 0.5rem;
-            border-radius: 3px;
-            border: 1px solid rgba(255, 255, 255, 0.05);
-          }
-        }
-        
-        .mini-preview {
-          background: linear-gradient(145deg, var(--color-warm-5), var(--color-warm-4));
-          border-color: var(--color-warm-3);
-          
-          &:hover {
-            background: linear-gradient(145deg, var(--color-warm-4), var(--color-warm-3));
-            border-color: var(--color-warm-2);
-          }
-          
-          label {
-            color: var(--color-warm-1);
-            
-            &::before {
-              color: var(--color-warm-2);
-              content: '★';
-            }
-          }
-          
-          .mini-format {
-            color: var(--color-warm-1);
-            font-weight: 700;
-            background: rgba(255, 200, 100, 0.1);
-            border-color: var(--color-warm-3);
-          }
+      &::-webkit-scrollbar-thumb {
+        background: var(--color-border-light-secondary);
+        border-radius: 3px;
+
+        &:hover {
+          background: var(--color-border-light-primary);
         }
       }
     }
 
-    .card-actions {
-      margin-top: 0.75rem;
+    .calendar-list-item {
+      display: flex;
       align-items: center;
       gap: 0.5rem;
+      padding: 0.625rem 0.75rem;
+      margin-bottom: 2px;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      background: transparent;
+      border: 1px solid transparent;
 
-      // Use native Foundry button styling
-      button.button {
-        flex: 1;
-        padding: 0.375rem 0.75rem;
-        font-size: 0.8rem;
-        
-        i {
-          margin-right: 0.25rem;
+      &:hover {
+        background: var(--color-bg-option);
+        border-color: var(--color-border-light-tertiary);
+      }
+
+      &.is-highlighted {
+        background: var(--color-bg-option);
+        border-color: var(--color-warm-2);
+        box-shadow: 0 0 4px rgba(255, 200, 100, 0.2);
+      }
+
+      &.is-current {
+        background: linear-gradient(145deg, var(--color-warm-5), transparent);
+
+        .current-badge {
+          color: var(--color-warm-1);
+          animation: current-star-pulse 2s infinite;
         }
       }
 
-      .selected-indicator {
-        color: var(--color-warm-1);
-        font-size: 1.1rem;
-        animation: foundry-pulse 2s infinite;
+      &.is-selected {
+        .selected-badge {
+          color: var(--color-warm-2);
+        }
+      }
+
+      .source-indicator {
+        font-size: 0.85rem;
+        color: var(--color-text-light-6);
+        width: 1.25rem;
+        text-align: center;
+        flex-shrink: 0;
+      }
+
+      .calendar-name {
+        flex: 1;
+        font-size: 0.9rem;
+        color: var(--color-text-light-primary);
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .current-badge,
+      .selected-badge {
+        flex-shrink: 0;
+        font-size: 0.8rem;
+      }
+
+      .variant-toggle {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        background: none;
+        border: none;
+        color: var(--color-text-light-6);
+        cursor: pointer;
+        padding: 0.25rem;
+        border-radius: 3px;
+
+        &:hover {
+          background: var(--color-bg-secondary);
+          color: var(--color-text-light-primary);
+        }
+
+        .variant-count {
+          font-size: 0.75rem;
+          background: var(--color-bg-secondary);
+          padding: 0.125rem 0.375rem;
+          border-radius: 10px;
+        }
+      }
+
+      // Variant items
+      &.variant-item {
+        padding-left: 2rem;
+        font-size: 0.85rem;
+
+        .variant-indicator {
+          color: var(--color-cool-2);
+          transform: rotate(45deg);
+        }
       }
     }
-  }
 
-  // No calendars state
-  .no-calendars {
-    padding: 3rem;
-    text-align: center;
-    color: var(--color-text-light-7);
-    min-height: 200px;
-    justify-content: center;
+    .empty-list-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      padding: 2rem;
+      color: var(--color-text-light-6);
 
-    .no-calendars-icon {
-      font-size: 3rem;
-      margin-bottom: 1rem;
-      opacity: 0.5;
-      color: var(--color-text-light-7);
-    }
-
-    .no-calendars-message {
-      h4 {
-        margin: 0 0 0.5rem 0;
-        color: var(--color-text-light-primary);
-        font-weight: 600;
+      i {
+        font-size: 2rem;
+        margin-bottom: 0.75rem;
+        opacity: 0.5;
       }
 
       p {
         margin: 0;
         font-size: 0.9rem;
-        max-width: 300px;
+        text-align: center;
       }
     }
   }
 
-  .dialog-buttons {
-    padding: 1rem;
-    gap: 0.75rem;
-    justify-content: flex-end;
-    margin-top: auto;
+  // ===== DETAIL PANE (RIGHT) =====
+  .calendar-detail-pane {
+    grid-row: 2;
+    grid-column: 2;
+    overflow-y: auto;
+    padding: 0.75rem;
+    background: var(--color-bg-alt);
 
-    button {
-      padding: 0.5rem 1rem;
-      font-size: 0.9rem;
+    .detail-content {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+      height: 100%;
+    }
 
-      i {
-        margin-right: 0.5rem;
+    .detail-header {
+      .calendar-name {
+        margin: 0 0 0.25rem 0;
+        font-size: 1.2rem;
+        font-weight: 600;
+        color: var(--color-text-light-primary);
       }
 
-      &.ss-button.primary {
-        background: var(--color-warm-2) !important;
-        color: white !important;
-        border-color: var(--color-warm-2) !important;
-        font-weight: 600;
+      .calendar-setting {
+        font-size: 0.85rem;
+        color: var(--color-text-light-6);
+        font-style: italic;
+      }
 
-        &:hover {
-          background: var(--color-warm-1) !important;
-          border-color: var(--color-warm-1) !important;
-          color: white !important;
+      .variant-info {
+        display: inline-block;
+        margin-top: 0.25rem;
+        font-size: 0.75rem;
+        color: var(--color-cool-2);
+        background: var(--color-bg-secondary);
+        padding: 0.125rem 0.5rem;
+        border-radius: 3px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+    }
+
+    .detail-description {
+      p {
+        margin: 0;
+        font-size: 0.85rem;
+        line-height: 1.5;
+        color: var(--color-text-light-primary);
+      }
+    }
+
+    // Well-style container for sample date and month browser
+    .detail-well {
+      padding: 0.75rem;
+      border-radius: 6px;
+      border: 2px solid var(--color-border-dark);
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+
+      // Light theme: darker inset
+      body.theme-light & {
+        background: rgba(0, 0, 0, 0.12);
+        box-shadow:
+          inset 0 2px 4px rgba(0, 0, 0, 0.25),
+          inset 0 -1px 2px rgba(255, 255, 255, 0.1);
+      }
+
+      // Dark theme: lighter inset
+      body.theme-dark & {
+        background: rgba(255, 255, 255, 0.06);
+        box-shadow:
+          inset 0 2px 4px rgba(0, 0, 0, 0.4),
+          inset 0 -1px 2px rgba(255, 255, 255, 0.08);
+      }
+
+      // Fallback for themes that don't set body class
+      background: rgba(0, 0, 0, 0.1);
+      box-shadow:
+        inset 0 2px 4px rgba(0, 0, 0, 0.2),
+        inset 0 -1px 2px rgba(255, 255, 255, 0.05);
+    }
+
+    .detail-sample {
+      text-align: center;
+
+      label {
+        display: block;
+        font-size: 0.7rem;
+        font-weight: 600;
+        color: var(--color-text-light-6);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 0.25rem;
+      }
+
+      .sample-date {
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: var(--color-text-light-primary);
+        letter-spacing: 0.3px;
+      }
+    }
+
+    // Month Browser
+    .month-browser {
+      background: var(--color-bg-option);
+      border: 1px solid var(--color-border-light-tertiary);
+      border-radius: 4px;
+      overflow: hidden;
+
+      .month-browser-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.375rem 0.5rem;
+        background: var(--color-bg-secondary);
+        border-bottom: 1px solid var(--color-border-light-tertiary);
+
+        .month-nav-btn {
+          background: none;
+          border: none;
+          color: var(--color-text-light-6);
+          cursor: pointer;
+          padding: 0.25rem 0.5rem;
+          border-radius: 3px;
+
+          &:hover {
+            background: var(--color-bg-option);
+            color: var(--color-text-light-primary);
+          }
+        }
+
+        .month-title {
+          font-size: 0.85rem;
+          font-weight: 600;
+          color: var(--color-text-light-primary);
+        }
+      }
+
+      .month-grid {
+        padding: 0.375rem;
+
+        .weekday-headers {
+          display: grid;
+          grid-template-columns: repeat(7, 1fr);
+          gap: 1px;
+          margin-bottom: 2px;
+
+          .weekday-header {
+            text-align: center;
+            font-size: 0.65rem;
+            font-weight: 600;
+            color: var(--color-text-light-6);
+            text-transform: uppercase;
+            padding: 0.125rem;
+          }
+        }
+
+        .day-cells {
+          display: grid;
+          grid-template-columns: repeat(7, 1fr);
+          gap: 1px;
+
+          .day-cell {
+            text-align: center;
+            font-size: 0.75rem;
+            color: var(--color-text-light-primary);
+            padding: 0.25rem;
+            border-radius: 2px;
+            background: var(--color-bg-secondary);
+
+            &.empty {
+              background: transparent;
+            }
+          }
+        }
+      }
+    }
+
+    .detail-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      align-items: flex-start;
+    }
+
+    .detail-tags {
+      flex: 1;
+
+      label {
+        display: block;
+        font-size: 0.7rem;
+        font-weight: 600;
+        color: var(--color-text-light-6);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: 0.25rem;
+      }
+
+      .tag-chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.25rem;
+
+        .tag-chip {
+          font-size: 0.7rem;
+          background: var(--color-bg-secondary);
+          color: var(--color-text-light-primary);
+          padding: 0.125rem 0.375rem;
+          border-radius: 10px;
+          border: 1px solid var(--color-border-light-tertiary);
+        }
+      }
+    }
+
+    .detail-source {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-size: 0.75rem;
+      color: var(--color-text-light-6);
+      padding: 0.25rem 0.5rem;
+      background: var(--color-bg-secondary);
+      border-radius: 4px;
+      border: 1px solid var(--color-border-light-tertiary);
+
+      i {
+        font-size: 0.8rem;
+      }
+    }
+
+    .detail-actions {
+      margin-top: auto;
+
+      .select-this-btn {
+        width: 100%;
+        padding: 0.5rem 1rem;
+        font-size: 0.85rem;
+        background: var(--color-bg-option);
+        border: 1px solid var(--color-border-light-secondary);
+        border-radius: 4px;
+        color: var(--color-text-light-primary);
+        cursor: pointer;
+        transition: all 0.2s ease;
+
+        &:hover:not(:disabled) {
+          background: var(--color-warm-4);
+          border-color: var(--color-warm-2);
+        }
+
+        &.selected {
+          background: var(--color-warm-2);
+          border-color: var(--color-warm-1);
+          color: white;
         }
 
         &:disabled {
           opacity: 0.6;
-          background: var(--color-bg-alt) !important;
-          color: var(--color-text-light-secondary) !important;
-          border-color: var(--color-border-light-secondary) !important;
+          cursor: not-allowed;
         }
+
+        i {
+          margin-right: 0.375rem;
+        }
+      }
+    }
+
+    .empty-detail-state {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: var(--color-text-light-6);
+
+      i {
+        font-size: 2.5rem;
+        margin-bottom: 0.75rem;
+        opacity: 0.3;
+      }
+
+      p {
+        margin: 0;
+        font-size: 0.9rem;
       }
     }
   }
-}
 
-// Calendar Preview Dialog Styles
-.seasons-stars.calendar-preview-dialog {
-  .calendar-preview {
-    padding: 1rem;
-    max-width: none;
-    
-    .preview-header {
-      margin-bottom: 1.5rem;
-      padding-bottom: 1rem;
-      border-bottom: 1px solid var(--color-border-light-secondary);
-      
-      h3 {
-        margin: 0 0 0.5rem 0;
-        font-size: 1.4rem;
-        font-weight: 600;
-        color: var(--color-text-light-primary);
-        line-height: 1.2;
-      }
-      
-      .preview-setting {
-        font-size: 0.9rem;
-        color: var(--color-text-light-secondary);
-        font-style: italic;
-        margin-top: 0.25rem;
-      }
+  // ===== CUSTOM FILE SECTION =====
+  .custom-file-section {
+    grid-column: 1 / -1;
+    padding: 0.625rem 1rem;
+    background: var(--color-bg-secondary);
+    border-top: 2px solid var(--color-border-light-secondary);
+
+    .custom-file-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      flex-wrap: wrap;
     }
-    
-    .preview-description {
-      margin-bottom: 1.5rem;
-      padding: 1rem;
-      background: var(--color-bg-secondary);
-      border: 1px solid var(--color-border-light-secondary);
-      border-radius: 4px;
-      font-size: 0.95rem;
-      line-height: 1.5;
+
+    .custom-file-label {
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      font-size: 0.85rem;
+      font-weight: 600;
       color: var(--color-text-light-primary);
-    }
-    
-    .preview-samples {
-      margin-bottom: 1.5rem;
-      
-      h4 {
-        margin: 0 0 0.75rem 0;
-        font-size: 1.1rem;
-        font-weight: 600;
-        color: var(--color-text-light-primary);
-        display: flex;
-        align-items: center;
-        
-        &::before {
-          content: "📅";
-          margin-right: 0.5rem;
-          font-size: 1rem;
-        }
+      flex-shrink: 0;
+
+      > i {
+        color: var(--color-text-light-6);
       }
-      
-      .sample-date {
-        background: var(--color-bg-option);
-        border: 1px solid var(--color-border-light-secondary);
-        border-radius: 3px;
-        padding: 0.5rem 0.75rem;
-        margin-bottom: 0.5rem;
+    }
+
+    .no-file-selected {
+      flex: 1;
+      font-size: 0.85rem;
+      color: var(--color-text-light-6);
+      font-style: italic;
+    }
+
+    .file-path-display {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      min-width: 0;
+      padding: 0.25rem 0.5rem;
+      background: var(--color-bg-option);
+      border: 1px solid var(--color-border-light-tertiary);
+      border-radius: 4px;
+
+      &.is-active {
+        border-color: var(--color-warm-2);
+        background: linear-gradient(90deg, var(--color-warm-5), var(--color-bg-option));
+      }
+
+      &.is-selected {
+        border-color: var(--color-warm-2);
+      }
+
+      > i {
+        flex-shrink: 0;
+        font-size: 0.8rem;
+        color: var(--color-text-light-6);
+      }
+
+      .path-text {
+        flex: 1;
+        font-size: 0.8rem;
         font-family: var(--font-mono);
-        font-size: 0.9rem;
         color: var(--color-text-light-primary);
-        font-weight: 500;
-        
-        &:last-child {
-          margin-bottom: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .status-badge {
+        display: flex;
+        align-items: center;
+        gap: 0.25rem;
+        flex-shrink: 0;
+        font-size: 0.7rem;
+        font-weight: 600;
+        padding: 0.125rem 0.375rem;
+        border-radius: 3px;
+
+        &.active {
+          color: var(--color-warm-1);
+          background: var(--color-warm-5);
+        }
+
+        &.selected {
+          color: white;
+          background: var(--color-warm-2);
+        }
+
+        i {
+          font-size: 0.65rem;
+        }
+      }
+
+      .clear-file-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        width: 1.25rem;
+        height: 1.25rem;
+        padding: 0;
+        margin-left: 0.25rem;
+        background: none;
+        border: none;
+        border-radius: 3px;
+        color: var(--color-text-light-6);
+        cursor: pointer;
+        transition: all 0.15s ease;
+
+        &:hover {
+          background: var(--color-bg-secondary);
+          color: var(--color-warm-1);
         }
       }
     }
-    
-    .preview-structure {
-      h4 {
-        margin: 0 0 0.75rem 0;
-        font-size: 1.1rem;
-        font-weight: 600;
-        color: var(--color-text-light-primary);
+
+    .file-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      flex-shrink: 0;
+
+      .browse-btn {
         display: flex;
         align-items: center;
-        
-        &::before {
-          content: "📊";
-          margin-right: 0.5rem;
-          font-size: 1rem;
+        gap: 0.375rem;
+        padding: 0.375rem 0.625rem;
+        font-size: 0.8rem;
+        background: var(--color-bg-option);
+        border: 1px solid var(--color-border-light-primary);
+        border-radius: 4px;
+        color: var(--color-text-light-primary);
+        cursor: pointer;
+        transition: all 0.15s ease;
+
+        &:hover {
+          background: var(--color-bg-primary);
+          border-color: var(--color-warm-2);
+        }
+
+        i {
+          font-size: 0.75rem;
         }
       }
-      
-      .structure-info {
-        background: var(--color-bg-secondary);
-        border: 1px solid var(--color-border-light-secondary);
+
+      .use-file-btn {
+        padding: 0.375rem 0.625rem;
+        font-size: 0.8rem;
+        background: var(--color-bg-option);
+        border: 1px solid var(--color-border-light-primary);
         border-radius: 4px;
-        padding: 1rem;
-        
-        div {
-          margin-bottom: 0.5rem;
-          font-size: 0.9rem;
-          color: var(--color-text-light-primary);
-          
-          &:last-child {
-            margin-bottom: 0;
-          }
-          
-          strong {
-            color: var(--color-text-light-primary);
-            font-weight: 600;
+        color: var(--color-text-light-primary);
+        cursor: pointer;
+        transition: all 0.15s ease;
+
+        &:hover {
+          background: var(--color-bg-primary);
+          border-color: var(--color-warm-2);
+        }
+
+        &.selected {
+          background: var(--color-warm-2);
+          border-color: var(--color-warm-1);
+          color: white;
+          font-weight: 500;
+
+          i {
             margin-right: 0.25rem;
           }
         }
@@ -648,86 +712,78 @@
     }
   }
 
-  .dialog-buttons {
-    padding: 1rem;
-    gap: 0.75rem;
+  // ===== FOOTER =====
+  .dialog-footer {
+    grid-column: 1 / -1;
+    display: flex;
     justify-content: flex-end;
-    margin-top: auto;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: var(--color-bg-option);
+    border-top: 2px solid var(--color-border-light-secondary);
 
     button {
       padding: 0.5rem 1rem;
       font-size: 0.9rem;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: all 0.15s ease;
 
       i {
-        margin-right: 0.5rem;
+        margin-right: 0.375rem;
+      }
+    }
+
+    .cancel-btn {
+      background: var(--color-bg-secondary);
+      border: 1px solid var(--color-border-light-secondary);
+      color: var(--color-text-light-primary);
+
+      &:hover {
+        background: var(--color-bg-primary);
+      }
+    }
+
+    .select-btn {
+      background: var(--color-warm-2);
+      border: 1px solid var(--color-warm-2);
+      color: white;
+      font-weight: 600;
+
+      &:hover:not(:disabled) {
+        background: var(--color-warm-1);
+        border-color: var(--color-warm-1);
       }
 
-      &.ss-button.primary {
-        background: var(--color-warm-2) !important;
-        color: white !important;
-        border-color: var(--color-warm-2) !important;
-        font-weight: 600;
-
-        &:hover {
-          background: var(--color-warm-1) !important;
-          border-color: var(--color-warm-1) !important;
-          color: white !important;
-        }
-
-        &:disabled {
-          opacity: 0.6;
-          background: var(--color-bg-alt) !important;
-          color: var(--color-text-light-secondary) !important;
-          border-color: var(--color-border-light-secondary) !important;
-        }
+      &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
       }
     }
   }
 }
 
-// Native Foundry pulse animation
-@keyframes foundry-pulse {
-  0%, 100% { 
-    opacity: 1; 
-    transform: scale(1);
-  }
-  50% { 
-    opacity: 0.7; 
-    transform: scale(1.05);
-  }
-}
-
-// Current star glow animation
-@keyframes current-star-glow {
-  0% {
-    filter: drop-shadow(0 0 4px var(--color-warm-1));
+// Animations
+@keyframes current-star-pulse {
+  0%, 100% {
+    opacity: 1;
     transform: scale(1);
   }
   50% {
-    filter: drop-shadow(0 0 8px var(--color-warm-1)) drop-shadow(0 0 16px var(--color-warm-2));
+    opacity: 0.7;
     transform: scale(1.1);
-  }
-  100% {
-    filter: drop-shadow(0 0 4px var(--color-warm-1));
-    transform: scale(1);
   }
 }
 
 // Light theme overrides
 body.theme-light {
   .seasons-stars.calendar-selection-dialog {
-    .calendar-badges {
-      .module-badge {
-        background: linear-gradient(135deg, var(--color-cool-4), var(--color-cool-3));
-        color: var(--color-text-dark-primary);
-        border: 1px solid var(--color-cool-2);
-      }
-      
-      .external-badge {
-        background: linear-gradient(135deg, var(--color-border-light-secondary), var(--color-border-light-tertiary));
-        color: var(--color-text-dark-primary);
-        border: 1px solid var(--color-border-light-primary);
-      }
+    .calendar-list-item.is-highlighted {
+      background: var(--color-bg-secondary);
+    }
+
+    .tag-chip {
+      background: var(--color-cool-5);
     }
   }
 }

--- a/packages/core/src/types/foundry-extensions.d.ts
+++ b/packages/core/src/types/foundry-extensions.d.ts
@@ -87,6 +87,7 @@ declare global {
     namespace utils {
       function mergeObject(original: any, other: any, options?: any): any;
       function deepClone(obj: any): any;
+      function debounce<T extends (...args: any[]) => any>(fn: T, delay: number): T;
     }
   }
   interface String {

--- a/packages/core/src/types/foundry-v13-essentials.d.ts
+++ b/packages/core/src/types/foundry-v13-essentials.d.ts
@@ -928,6 +928,7 @@ interface FoundryNamespace {
   utils: {
     deepClone<T>(obj: T): T;
     mergeObject<T, U>(original: T, other: U, options?: any): T & U;
+    debounce<T extends (...args: any[]) => any>(fn: T, delay: number): T;
   };
 }
 

--- a/packages/core/src/ui/calendar-selection-dialog.ts
+++ b/packages/core/src/ui/calendar-selection-dialog.ts
@@ -17,6 +17,45 @@ import {
   resolveCalendarFilePath,
 } from './calendar-file-helpers.js';
 
+/**
+ * Represents a calendar item in the list view
+ */
+interface CalendarListItem {
+  id: string;
+  label: string;
+  description: string | undefined;
+  setting: string | undefined;
+  sampleDate: string;
+  miniPreview: string;
+  isCurrent: boolean;
+  isSelected: boolean;
+  isHighlighted: boolean;
+  isVariant: boolean;
+  variantInfo: string;
+  baseCalendarId: string;
+  sourceType: 'builtin' | 'module' | 'external';
+  sourceIcon: string;
+  sourceLabel: string;
+  sourceDescription: string;
+  isModuleSource: boolean;
+  isBuiltinSource: boolean;
+  isExternalSource: boolean;
+  tags: string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  monthPreview?: any;
+}
+
+/**
+ * Represents a grouped calendar with its variants
+ */
+interface GroupedCalendar {
+  id: string;
+  base: CalendarListItem | null;
+  variants: CalendarListItem[];
+  isExpanded: boolean;
+  hasVariants: boolean;
+}
+
 export class CalendarSelectionDialog extends foundry.applications.api.HandlebarsApplicationMixin(
   foundry.applications.api.ApplicationV2
 ) {
@@ -26,6 +65,15 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
   private externalSources: Map<string, ExternalCalendarSource>;
   private currentCalendarId: string;
   private pendingFilePath: string | null = null; // Track file selection before confirmation
+
+  // New state for master-detail UI
+  private searchQuery: string = '';
+  private selectedTags: string[] = [];
+  private expandedVariantGroups: Set<string> = new Set();
+  private highlightedCalendarId: string | null = null;
+  private detailViewMonth: number = 1;
+  private detailViewYear: number = 1000;
+  private searchDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(
     calendars?: Map<string, SeasonsStarsCalendar> | SeasonsStarsCalendar[],
@@ -126,8 +174,8 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
       resizable: true,
     },
     position: {
-      width: 600,
-      height: 750,
+      width: 850,
+      height: 650,
     },
     actions: {
       selectCalendar: CalendarSelectionDialog.prototype._onSelectCalendar,
@@ -136,14 +184,35 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
       cancel: CalendarSelectionDialog.prototype._onCancel,
       openFilePicker: CalendarSelectionDialog.prototype._onOpenFilePicker,
       clearFilePicker: CalendarSelectionDialog.prototype._onClearFilePicker,
+      // New actions for master-detail UI
+      highlightCalendar: CalendarSelectionDialog.prototype._onHighlightCalendar,
+      toggleVariants: CalendarSelectionDialog.prototype._onToggleVariants,
+      browseMonth: CalendarSelectionDialog.prototype._onBrowseMonth,
+      clearFilters: CalendarSelectionDialog.prototype._onClearFilters,
     },
   };
 
   static PARTS = {
-    main: {
-      id: 'main',
-      template: 'modules/seasons-and-stars/templates/calendar-selection-dialog.hbs',
-      scrollable: ['.calendar-selection-grid'],
+    header: {
+      id: 'header',
+      template: 'modules/seasons-and-stars/templates/calendar-selection/header.hbs',
+    },
+    list: {
+      id: 'list',
+      template: 'modules/seasons-and-stars/templates/calendar-selection/list.hbs',
+      scrollable: ['.calendar-list-container'],
+    },
+    detail: {
+      id: 'detail',
+      template: 'modules/seasons-and-stars/templates/calendar-selection/detail.hbs',
+    },
+    filePicker: {
+      id: 'file-picker',
+      template: 'modules/seasons-and-stars/templates/calendar-selection/file-picker.hbs',
+    },
+    footer: {
+      id: 'footer',
+      template: 'modules/seasons-and-stars/templates/calendar-selection/footer.hbs',
     },
   };
 
@@ -169,9 +238,67 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
     } else if (activeCalendarSetting) {
       this.currentCalendarId = activeCalendarSetting;
     }
-    const showFilePicker = true;
 
-    const calendarsData = Array.from(this.calendars.entries()).map(([id, calendar]) => {
+    // Build calendar list items
+    const calendarsData = this.buildCalendarListItems();
+
+    // Get all available tags for the filter dropdown
+    const availableTags = this.getAllTags();
+
+    // Apply filters (search query and selected tags)
+    const filteredCalendars = this.filterCalendars(calendarsData);
+
+    // Group calendars hierarchically
+    const groupedCalendars = this.groupCalendars(filteredCalendars);
+
+    // Get highlighted calendar data for detail pane
+    const highlightedCalendar = this.highlightedCalendarId
+      ? this.getHighlightedCalendarData(calendarsData)
+      : null;
+
+    // Determine if file picker should be considered "selected"
+    const filePickerSelected =
+      selectedFilePath !== '' &&
+      (this.selectedCalendarId === '__FILE_PICKER__' || filePickerActive);
+
+    // Check if there are active filters
+    const hasActiveFilters = this.searchQuery !== '' || this.selectedTags.length > 0;
+
+    return Object.assign(context, {
+      // List data
+      groupedCalendars,
+      totalCount: calendarsData.length,
+      filteredCount: filteredCalendars.length,
+
+      // Search/filter state
+      searchQuery: this.searchQuery,
+      selectedTags: this.selectedTags,
+      availableTags,
+      hasActiveFilters,
+
+      // Detail pane data
+      highlightedCalendar,
+      highlightedCalendarId: this.highlightedCalendarId,
+      detailViewMonth: this.detailViewMonth,
+      detailViewYear: this.detailViewYear,
+
+      // Selection state
+      selectedCalendar: this.selectedCalendarId,
+      currentCalendar: this.currentCalendarId,
+
+      // File picker state
+      showFilePicker: true,
+      selectedFilePath,
+      filePickerActive,
+      filePickerSelected,
+    });
+  }
+
+  /**
+   * Build calendar list items from the calendars map
+   */
+  private buildCalendarListItems(): CalendarListItem[] {
+    return Array.from(this.calendars.entries()).map(([id, calendar]) => {
       const label = CalendarLocalization.getCalendarLabel(calendar);
       const description = CalendarLocalization.getCalendarDescription(calendar);
       const setting = CalendarLocalization.getCalendarSetting(calendar);
@@ -182,7 +309,6 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
       let baseCalendarId = id;
 
       if (isVariant) {
-        // Extract base calendar ID and variant name
         const match = id.match(/^(.+)\((.+)\)$/);
         if (match) {
           baseCalendarId = match[1];
@@ -194,12 +320,11 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
       // Determine the source type and metadata
       const sourceInfo = this.getCalendarSourceInfo(id);
 
-      // Use collection preview if available, otherwise generate sample date
+      // Get collection entry for tags and preview
       const collectionEntry = this.collectionEntries.get(id);
       const sampleDate = collectionEntry?.preview || this.generateSampleDate(calendar);
-
-      // Generate mini widget preview (use collection preview for consistency if available)
       const miniPreview = collectionEntry?.preview || this.generateMiniWidgetPreview(calendar);
+      const tags = collectionEntry?.tags || [];
 
       return {
         id,
@@ -210,6 +335,7 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
         miniPreview,
         isCurrent: id === this.currentCalendarId,
         isSelected: id === this.selectedCalendarId,
+        isHighlighted: id === this.highlightedCalendarId,
         isVariant,
         variantInfo,
         baseCalendarId,
@@ -220,75 +346,179 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
         isModuleSource: sourceInfo.type === 'module',
         isBuiltinSource: sourceInfo.type === 'builtin',
         isExternalSource: sourceInfo.type === 'external',
+        tags,
       };
     });
+  }
 
-    // Group calendars hierarchically by base calendar
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const calendarGroups = new Map<string, { base: any | null; variants: any[] }>();
+  /**
+   * Get all unique tags from all calendars
+   */
+  private getAllTags(): string[] {
+    const tagSet = new Set<string>();
+    for (const entry of this.collectionEntries.values()) {
+      if (entry.tags) {
+        entry.tags.forEach(tag => tagSet.add(tag));
+      }
+    }
+    return Array.from(tagSet).sort();
+  }
 
-    for (const calendar of calendarsData) {
-      if (!calendarGroups.has(calendar.baseCalendarId)) {
-        calendarGroups.set(calendar.baseCalendarId, { base: null, variants: [] });
+  /**
+   * Filter calendars based on search query and selected tags
+   */
+  private filterCalendars(calendars: CalendarListItem[]): CalendarListItem[] {
+    let filtered = calendars;
+
+    // Apply search query filter
+    if (this.searchQuery) {
+      const query = this.searchQuery.toLowerCase();
+      filtered = filtered.filter(cal => {
+        const searchText = `${cal.label} ${cal.description} ${cal.tags.join(' ')}`.toLowerCase();
+        return searchText.includes(query);
+      });
+    }
+
+    // Apply tag filter (any match)
+    if (this.selectedTags.length > 0) {
+      filtered = filtered.filter(cal => {
+        return this.selectedTags.some(tag => cal.tags.includes(tag));
+      });
+    }
+
+    return filtered;
+  }
+
+  /**
+   * Group calendars by base calendar with variants nested
+   */
+  private groupCalendars(calendars: CalendarListItem[]): GroupedCalendar[] {
+    const groups = new Map<string, GroupedCalendar>();
+
+    // Build groups
+    for (const calendar of calendars) {
+      const baseId = calendar.baseCalendarId;
+
+      if (!groups.has(baseId)) {
+        // Check if this group should be expanded
+        const isExpanded =
+          this.expandedVariantGroups.has(baseId) ||
+          // Auto-expand if current calendar is in this group
+          calendar.isCurrent ||
+          // Auto-expand if highlighted calendar is in this group
+          calendar.isHighlighted;
+
+        groups.set(baseId, {
+          id: baseId,
+          base: null,
+          variants: [],
+          isExpanded,
+          hasVariants: false,
+        });
       }
 
-      const group = calendarGroups.get(calendar.baseCalendarId);
-      if (!group) continue;
+      const group = groups.get(baseId)!;
       if (calendar.isVariant) {
         group.variants.push(calendar);
+        group.hasVariants = true;
       } else {
         group.base = calendar;
+      }
+
+      // Update expansion state based on current/highlighted
+      if (calendar.isCurrent || calendar.isHighlighted) {
+        group.isExpanded = true;
       }
     }
 
     // Sort groups with Gregorian first, then alphabetically
-    const sortedGroups = Array.from(calendarGroups.entries()).sort(
-      ([aId, aGroup], [bId, bGroup]) => {
-        // Gregorian calendar always comes first
-        if (aId === 'gregorian') return -1;
-        if (bId === 'gregorian') return 1;
+    const sortedGroups = Array.from(groups.values()).sort((a, b) => {
+      if (a.id === 'gregorian') return -1;
+      if (b.id === 'gregorian') return 1;
 
-        // All other calendars sorted alphabetically by display label
-        const labelA = aGroup.base ? aGroup.base.label : aId;
-        const labelB = bGroup.base ? bGroup.base.label : bId;
-        return labelA.localeCompare(labelB);
-      }
-    );
+      const labelA = a.base ? a.base.label : a.id;
+      const labelB = b.base ? b.base.label : b.id;
+      return labelA.localeCompare(labelB);
+    });
 
-    // Build hierarchical calendar list
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const sortedCalendars: any[] = [];
-    for (const [, group] of sortedGroups) {
-      // Add base calendar first
-      if (group.base) {
-        sortedCalendars.push(group.base);
-      }
-
-      // Sort variants alphabetically and add with hierarchy indicator
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      group.variants.sort((a: any, b: any) => a.label.localeCompare(b.label));
-      for (const variant of group.variants) {
-        // Add visual hierarchy level for CSS styling
-        variant.hierarchyLevel = 1;
-        sortedCalendars.push(variant);
-      }
+    // Sort variants within each group
+    for (const group of sortedGroups) {
+      group.variants.sort((a, b) => a.label.localeCompare(b.label));
     }
 
-    // Determine if file picker should be considered "selected"
-    // Only show as selected if there's actually a file selected AND it's either the selected ID or is currently active
-    const filePickerSelected =
-      selectedFilePath !== '' &&
-      (this.selectedCalendarId === '__FILE_PICKER__' || filePickerActive);
+    return sortedGroups;
+  }
 
-    return Object.assign(context, {
-      calendars: sortedCalendars,
-      selectedCalendar: this.selectedCalendarId,
-      currentCalendar: this.currentCalendarId,
-      showFilePicker,
-      selectedFilePath,
-      filePickerActive,
-      filePickerSelected,
-    });
+  /**
+   * Get data for the highlighted calendar (for detail pane)
+   */
+  private getHighlightedCalendarData(calendars: CalendarListItem[]): CalendarListItem | null {
+    const highlighted = calendars.find(c => c.id === this.highlightedCalendarId);
+    if (!highlighted) return null;
+
+    // Add month preview data for the detail pane
+    const calendar = this.calendars.get(highlighted.id);
+    if (calendar) {
+      // Generate month preview data and add to the highlighted item
+      highlighted.monthPreview = this.generateMonthPreviewData(calendar);
+    }
+
+    return highlighted;
+  }
+
+  /**
+   * Generate month preview data for the detail pane
+   */
+  private generateMonthPreviewData(calendar: SeasonsStarsCalendar): {
+    monthName: string;
+    year: number;
+    days: number[];
+    weekdayHeaders: string[];
+  } {
+    // Ensure month index is valid
+    const monthIndex = Math.max(0, Math.min(this.detailViewMonth - 1, calendar.months.length - 1));
+    const month = calendar.months[monthIndex];
+
+    // Get localized month name
+    const monthName = CalendarLocalization.getCalendarTranslation(
+      calendar,
+      `months.${month.id || month.name}`,
+      month.name
+    );
+
+    // Generate weekday headers
+    const weekdayHeaders = calendar.weekdays.map(wd =>
+      CalendarLocalization.getCalendarTranslation(
+        calendar,
+        `weekdays.${wd.id || wd.name}`,
+        wd.abbreviation || wd.name.substring(0, 2)
+      )
+    );
+
+    // Generate day numbers for the month
+    const days: number[] = [];
+    const daysInMonth = month.days;
+
+    // Calculate what weekday the month starts on (simplified - just use first day of first month of year)
+    // This is an approximation for the preview
+    const startWeekday = 0; // Simplified: assume month starts on first weekday
+
+    // Add empty cells for days before the month starts
+    for (let i = 0; i < startWeekday; i++) {
+      days.push(0); // 0 represents empty cell
+    }
+
+    // Add the actual days
+    for (let day = 1; day <= daysInMonth; day++) {
+      days.push(day);
+    }
+
+    return {
+      monthName,
+      year: this.detailViewYear,
+      days,
+      weekdayHeaders,
+    };
   }
 
   /** @override */
@@ -297,42 +527,103 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
     super._attachPartListeners(partId, htmlElement, options);
 
     Logger.debug('Attaching part listeners', { partId, element: htmlElement });
-    Logger.debug('Scrollable elements', htmlElement.querySelectorAll('.calendar-selection-grid'));
 
-    // Add action buttons to window and update button state after rendering
-    this.addActionButtons($(htmlElement));
-    this.updateSelectButton($(htmlElement));
+    // Handle search input with debouncing (header part)
+    if (partId === 'header') {
+      const searchInput = htmlElement.querySelector<HTMLInputElement>('.calendar-search-input');
+      if (searchInput) {
+        searchInput.addEventListener('input', e => {
+          const target = e.target as HTMLInputElement;
+          this.handleSearchInput(target.value);
+        });
 
-    // Debug: Check if scrolling is working
-    const scrollableGrid = htmlElement.querySelector('.calendar-selection-grid');
-    if (scrollableGrid) {
-      const style = getComputedStyle(scrollableGrid);
-      Logger.debug('Found scrollable grid', {
-        overflow: style.overflow,
-        clientHeight: scrollableGrid.clientHeight,
-        scrollHeight: scrollableGrid.scrollHeight,
-      });
+        // Restore focus to search input if it had focus before re-render
+        if (document.activeElement?.classList.contains('calendar-search-input')) {
+          searchInput.focus();
+        }
+      }
+
+      // Handle tag filter changes
+      const tagFilter = htmlElement.querySelector<HTMLSelectElement>('.tag-filter');
+      if (tagFilter) {
+        tagFilter.addEventListener('change', () => {
+          this.handleTagFilterChange(tagFilter);
+        });
+      }
+    }
+
+    // Handle list scrolling and keyboard navigation (list part)
+    if (partId === 'list') {
+      const listContainer = htmlElement.querySelector('.calendar-list-container');
+      if (listContainer) {
+        listContainer.addEventListener('keydown', e => this.handleListKeydown(e as KeyboardEvent));
+      }
+    }
+
+    // Update select button state (footer part)
+    if (partId === 'footer') {
+      this.updateSelectButton($(htmlElement));
     }
   }
 
   /**
-   * Add action buttons to the dialog
+   * Handle search input with debouncing
    */
-  private addActionButtons(html: JQuery): void {
-    const footer = $(`
-      <div class="dialog-buttons flexrow">
-        <button data-action="cancel" type="button" class="button">
-          <i class="fas fa-times"></i>
-          ${game.i18n.localize('SEASONS_STARS.dialog.calendar_selection.cancel')}
-        </button>
-        <button data-action="chooseCalendar" type="button" class="button ss-button primary" id="select-calendar">
-          <i class="fas fa-check"></i>
-          ${game.i18n.localize('SEASONS_STARS.dialog.calendar_selection.select')}
-        </button>
-      </div>
-    `);
+  private handleSearchInput(value: string): void {
+    // Clear existing debounce timer
+    if (this.searchDebounceTimer) {
+      clearTimeout(this.searchDebounceTimer);
+    }
 
-    html.append(footer);
+    // Debounce the search for 300ms
+    this.searchDebounceTimer = setTimeout(() => {
+      this.searchQuery = value;
+      // Re-render only the list part
+      this.render({ parts: ['list'] });
+    }, 300);
+  }
+
+  /**
+   * Handle tag filter selection changes
+   */
+  private handleTagFilterChange(selectElement: HTMLSelectElement): void {
+    const selectedOptions = Array.from(selectElement.selectedOptions);
+    this.selectedTags = selectedOptions.map(opt => opt.value);
+    // Re-render the list
+    this.render({ parts: ['list', 'header'] });
+  }
+
+  /**
+   * Handle keyboard navigation in the list
+   */
+  private handleListKeydown(event: KeyboardEvent): void {
+    const calendars = this.buildCalendarListItems();
+    const filtered = this.filterCalendars(calendars);
+    const currentIndex = filtered.findIndex(c => c.id === this.highlightedCalendarId);
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        if (currentIndex < filtered.length - 1) {
+          this.highlightedCalendarId = filtered[currentIndex + 1].id;
+          this.render({ parts: ['list', 'detail'] });
+        }
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (currentIndex > 0) {
+          this.highlightedCalendarId = filtered[currentIndex - 1].id;
+          this.render({ parts: ['list', 'detail'] });
+        }
+        break;
+      case 'Enter':
+        event.preventDefault();
+        if (this.highlightedCalendarId) {
+          this.selectedCalendarId = this.highlightedCalendarId;
+          this.render({ parts: ['list', 'footer'] });
+        }
+        break;
+    }
   }
 
   /**
@@ -876,6 +1167,100 @@ export class CalendarSelectionDialog extends foundry.applications.api.Handlebars
       Logger.error('Failed to clear file picker:', error as Error);
       ui.notifications?.error(game.i18n.localize('SEASONS_STARS.errors.clear_file_failed'));
     }
+  }
+
+  /**
+   * Instance action handler for highlighting a calendar in the list (updates detail pane)
+   */
+  async _onHighlightCalendar(event: Event, target: HTMLElement): Promise<void> {
+    const calendarId = target.getAttribute('data-calendar-id');
+    Logger.debug('Highlight calendar', { calendarId });
+
+    if (calendarId) {
+      this.highlightedCalendarId = calendarId;
+
+      // Also select this calendar (clicking = selecting)
+      this.selectCalendarCard(calendarId);
+
+      // Reset month view when changing calendars
+      this.detailViewMonth = 1;
+
+      // Get calendar to set a reasonable default year
+      const calendar = this.calendars.get(calendarId);
+      if (calendar) {
+        // Use a sample year based on the calendar's epoch or default
+        this.detailViewYear = 1000;
+      }
+
+      // Re-render list (for highlight state), detail pane, and footer
+      this.render({ parts: ['list', 'detail', 'footer'] });
+    }
+  }
+
+  /**
+   * Instance action handler for toggling variant group expansion
+   */
+  async _onToggleVariants(event: Event, target: HTMLElement): Promise<void> {
+    event.stopPropagation();
+
+    const baseId = target.getAttribute('data-base-id');
+    Logger.debug('Toggle variants', { baseId });
+
+    if (baseId) {
+      if (this.expandedVariantGroups.has(baseId)) {
+        this.expandedVariantGroups.delete(baseId);
+      } else {
+        this.expandedVariantGroups.add(baseId);
+      }
+
+      // Re-render list only
+      this.render({ parts: ['list'] });
+    }
+  }
+
+  /**
+   * Instance action handler for browsing months in the detail pane
+   */
+  async _onBrowseMonth(event: Event, target: HTMLElement): Promise<void> {
+    const direction = target.getAttribute('data-direction');
+    Logger.debug('Browse month', { direction });
+
+    if (!this.highlightedCalendarId) return;
+
+    const calendar = this.calendars.get(this.highlightedCalendarId);
+    if (!calendar) return;
+
+    const totalMonths = calendar.months.length;
+
+    if (direction === 'prev') {
+      this.detailViewMonth--;
+      if (this.detailViewMonth < 1) {
+        this.detailViewMonth = totalMonths;
+        this.detailViewYear--;
+      }
+    } else if (direction === 'next') {
+      this.detailViewMonth++;
+      if (this.detailViewMonth > totalMonths) {
+        this.detailViewMonth = 1;
+        this.detailViewYear++;
+      }
+    }
+
+    // Re-render detail pane only
+    this.render({ parts: ['detail'] });
+  }
+
+  /**
+   * Instance action handler for clearing search/tag filters
+   */
+  async _onClearFilters(_event: Event, _target: HTMLElement): Promise<void> {
+    Logger.debug('Clear filters');
+
+    this.searchQuery = '';
+    this.selectedTags = [];
+
+    // Re-render header (to clear search input) and list
+    this.render({ parts: ['header', 'list'] });
   }
 
   /**

--- a/packages/core/templates/calendar-selection/detail.hbs
+++ b/packages/core/templates/calendar-selection/detail.hbs
@@ -1,0 +1,84 @@
+<section class="calendar-detail-pane" data-application-part="detail" aria-live="polite">
+  {{#if highlightedCalendar}}
+    <div class="detail-content">
+      <div class="detail-header">
+        <h3 class="calendar-name">{{highlightedCalendar.label}}</h3>
+        {{#if highlightedCalendar.setting}}
+        <span class="calendar-setting">{{highlightedCalendar.setting}}</span>
+        {{/if}}
+        {{#if highlightedCalendar.variantInfo}}
+        <span class="variant-info">{{highlightedCalendar.variantInfo}}</span>
+        {{/if}}
+      </div>
+
+      {{#if highlightedCalendar.description}}
+      <div class="detail-description">
+        <p>{{highlightedCalendar.description}}</p>
+      </div>
+      {{/if}}
+
+      {{!-- Well container for sample date and month browser --}}
+      <div class="detail-well">
+        <div class="detail-sample">
+          <label>{{localize "SEASONS_STARS.dialog.calendar_selection.sample"}}</label>
+          <span class="sample-date">{{highlightedCalendar.sampleDate}}</span>
+        </div>
+
+        {{!-- Month Browser --}}
+        {{#if highlightedCalendar.monthPreview}}
+        <div class="month-browser">
+          <div class="month-browser-header">
+            <button type="button" class="month-nav-btn" data-action="browseMonth" data-direction="prev" aria-label="{{localize 'SEASONS_STARS.dialog.calendar_selection.prev_month'}}">
+              <i class="fas fa-chevron-left"></i>
+            </button>
+            <span class="month-title">{{highlightedCalendar.monthPreview.monthName}} {{highlightedCalendar.monthPreview.year}}</span>
+            <button type="button" class="month-nav-btn" data-action="browseMonth" data-direction="next" aria-label="{{localize 'SEASONS_STARS.dialog.calendar_selection.next_month'}}">
+              <i class="fas fa-chevron-right"></i>
+            </button>
+          </div>
+          <div class="month-grid">
+            <div class="weekday-headers">
+              {{#each highlightedCalendar.monthPreview.weekdayHeaders}}
+              <span class="weekday-header">{{this}}</span>
+              {{/each}}
+            </div>
+            <div class="day-cells">
+              {{#each highlightedCalendar.monthPreview.days}}
+                {{#if this}}
+                <span class="day-cell">{{this}}</span>
+                {{else}}
+                <span class="day-cell empty"></span>
+                {{/if}}
+              {{/each}}
+            </div>
+          </div>
+        </div>
+        {{/if}}
+      </div>
+
+      {{!-- Tags and Source in a row --}}
+      <div class="detail-meta">
+        {{#if highlightedCalendar.tags.length}}
+        <div class="detail-tags">
+          <label>{{localize "SEASONS_STARS.dialog.calendar_selection.tags"}}</label>
+          <div class="tag-chips">
+            {{#each highlightedCalendar.tags}}
+            <span class="tag-chip">{{this}}</span>
+            {{/each}}
+          </div>
+        </div>
+        {{/if}}
+
+        <div class="detail-source">
+          <i class="{{highlightedCalendar.sourceIcon}}"></i>
+          <span class="source-label">{{highlightedCalendar.sourceLabel}}</span>
+        </div>
+      </div>
+    </div>
+  {{else}}
+    <div class="empty-detail-state">
+      <i class="fas fa-calendar-alt"></i>
+      <p>{{localize "SEASONS_STARS.dialog.calendar_selection.select_to_view"}}</p>
+    </div>
+  {{/if}}
+</section>

--- a/packages/core/templates/calendar-selection/file-picker.hbs
+++ b/packages/core/templates/calendar-selection/file-picker.hbs
@@ -1,0 +1,48 @@
+<section class="custom-file-section" data-application-part="file-picker">
+  <div class="custom-file-row">
+    <div class="custom-file-label">
+      <i class="fas fa-file-import"></i>
+      <span>{{localize "SEASONS_STARS.dialog.calendar_selection.custom_file"}}:</span>
+    </div>
+    {{#if selectedFilePath}}
+    <div class="file-path-display {{#if filePickerActive}}is-active{{/if}} {{#if filePickerSelected}}is-selected{{/if}}">
+      <i class="fas fa-file-code"></i>
+      <span class="path-text" data-tooltip="{{selectedFilePath}}">{{selectedFilePath}}</span>
+      {{#if filePickerActive}}
+      <span class="status-badge active">
+        <i class="fas fa-star"></i>
+        {{localize "SEASONS_STARS.dialog.calendar_selection.current"}}
+      </span>
+      {{else if filePickerSelected}}
+      <span class="status-badge selected">
+        <i class="fas fa-check"></i>
+        {{localize "SEASONS_STARS.dialog.calendar_selection.selected"}}
+      </span>
+      {{/if}}
+      <button type="button" class="clear-file-btn" data-action="clearFilePicker" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.clear_file'}}">
+        <i class="fas fa-times"></i>
+      </button>
+    </div>
+    {{else}}
+    <span class="no-file-selected">{{localize "SEASONS_STARS.dialog.calendar_selection.no_file_selected"}}</span>
+    {{/if}}
+    <div class="file-actions">
+      <button type="button" class="browse-btn" data-action="openFilePicker">
+        <i class="fas fa-folder-open"></i>
+        {{localize "SEASONS_STARS.dialog.calendar_selection.browse"}}
+      </button>
+      {{#if selectedFilePath}}
+      {{#unless filePickerActive}}
+      {{#unless filePickerSelected}}
+      <button type="button"
+              class="use-file-btn"
+              data-action="selectCalendar"
+              data-calendar-id="__FILE_PICKER__">
+        {{localize "SEASONS_STARS.dialog.calendar_selection.use_this_file"}}
+      </button>
+      {{/unless}}
+      {{/unless}}
+      {{/if}}
+    </div>
+  </div>
+</section>

--- a/packages/core/templates/calendar-selection/footer.hbs
+++ b/packages/core/templates/calendar-selection/footer.hbs
@@ -1,0 +1,18 @@
+<footer class="dialog-footer" data-application-part="footer">
+  <button type="button" data-action="cancel" class="cancel-btn">
+    <i class="fas fa-times"></i>
+    {{localize "SEASONS_STARS.dialog.calendar_selection.cancel"}}
+  </button>
+  <button type="button"
+          data-action="chooseCalendar"
+          class="select-btn ss-button primary"
+          id="select-calendar"
+          {{#unless selectedCalendar}}disabled{{/unless}}>
+    <i class="fas fa-check"></i>
+    {{#if selectedCalendar}}
+      {{localize "SEASONS_STARS.dialog.calendar_selection.select"}}
+    {{else}}
+      {{localize "SEASONS_STARS.dialog.calendar_selection.select"}}
+    {{/if}}
+  </button>
+</footer>

--- a/packages/core/templates/calendar-selection/header.hbs
+++ b/packages/core/templates/calendar-selection/header.hbs
@@ -1,0 +1,31 @@
+<section class="calendar-search-header" data-application-part="header">
+  <div class="search-input-container">
+    <i class="fas fa-search"></i>
+    <input type="search"
+           class="calendar-search-input"
+           placeholder="{{localize 'SEASONS_STARS.dialog.calendar_selection.search_placeholder'}}"
+           value="{{searchQuery}}"
+           aria-label="{{localize 'SEASONS_STARS.dialog.calendar_selection.search_placeholder'}}">
+    {{#if hasActiveFilters}}
+    <button type="button" class="clear-filters-btn" data-action="clearFilters" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.clear_filters'}}">
+      <i class="fas fa-times"></i>
+    </button>
+    {{/if}}
+  </div>
+
+  {{#if availableTags.length}}
+  <div class="tag-filter-container">
+    <select class="tag-filter" multiple aria-label="{{localize 'SEASONS_STARS.dialog.calendar_selection.filter_by_tag'}}">
+      {{#each availableTags}}
+      <option value="{{this}}" {{#if (includes ../selectedTags this)}}selected{{/if}}>
+        {{this}}
+      </option>
+      {{/each}}
+    </select>
+  </div>
+  {{/if}}
+
+  <div class="result-count">
+    {{filteredCount}} {{localize "SEASONS_STARS.dialog.calendar_selection.of"}} {{totalCount}}
+  </div>
+</section>

--- a/packages/core/templates/calendar-selection/list.hbs
+++ b/packages/core/templates/calendar-selection/list.hbs
@@ -1,0 +1,72 @@
+<section class="calendar-list-pane" data-application-part="list">
+  <div class="calendar-list-container" role="listbox" aria-label="{{localize 'SEASONS_STARS.dialog.calendar_selection.choose_calendar'}}" tabindex="0">
+    {{#each groupedCalendars}}
+      {{!-- Base Calendar --}}
+      {{#if base}}
+      <div class="calendar-list-item {{#if base.isCurrent}}is-current{{/if}} {{#if base.isSelected}}is-selected{{/if}} {{#if base.isHighlighted}}is-highlighted{{/if}}"
+           role="option"
+           aria-selected="{{#if base.isHighlighted}}true{{else}}false{{/if}}"
+           data-action="highlightCalendar"
+           data-calendar-id="{{base.id}}"
+           tabindex="{{#if base.isHighlighted}}0{{else}}-1{{/if}}">
+        <i class="{{base.sourceIcon}} source-indicator" data-tooltip="{{base.sourceLabel}}"></i>
+        <span class="calendar-name">{{base.label}}</span>
+        {{#if base.isCurrent}}
+        <span class="current-badge" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.current'}}">
+          <i class="fas fa-star"></i>
+        </span>
+        {{/if}}
+        {{#if base.isSelected}}
+        <span class="selected-badge">
+          <i class="fas fa-check"></i>
+        </span>
+        {{/if}}
+        {{#if hasVariants}}
+        <button type="button"
+                class="variant-toggle"
+                data-action="toggleVariants"
+                data-base-id="{{id}}"
+                aria-expanded="{{isExpanded}}"
+                aria-label="{{localize 'SEASONS_STARS.dialog.calendar_selection.toggle_variants'}}">
+          <i class="fas fa-chevron-{{#if isExpanded}}down{{else}}right{{/if}}"></i>
+          <span class="variant-count">{{variants.length}}</span>
+        </button>
+        {{/if}}
+      </div>
+      {{/if}}
+
+      {{!-- Variants (if expanded) --}}
+      {{#if isExpanded}}
+        {{#each variants}}
+        <div class="calendar-list-item variant-item {{#if isCurrent}}is-current{{/if}} {{#if isSelected}}is-selected{{/if}} {{#if isHighlighted}}is-highlighted{{/if}}"
+             role="option"
+             aria-selected="{{#if isHighlighted}}true{{else}}false{{/if}}"
+             data-action="highlightCalendar"
+             data-calendar-id="{{id}}"
+             tabindex="{{#if isHighlighted}}0{{else}}-1{{/if}}">
+          <i class="fas fa-code-branch variant-indicator"></i>
+          <span class="calendar-name">{{label}}</span>
+          {{#if isCurrent}}
+          <span class="current-badge" data-tooltip="{{localize 'SEASONS_STARS.dialog.calendar_selection.current'}}">
+            <i class="fas fa-star"></i>
+          </span>
+          {{/if}}
+          {{#if isSelected}}
+          <span class="selected-badge">
+            <i class="fas fa-check"></i>
+          </span>
+          {{/if}}
+        </div>
+        {{/each}}
+      {{/if}}
+    {{/each}}
+
+    {{!-- Empty state when no calendars match filter --}}
+    {{#unless filteredCount}}
+    <div class="empty-list-state">
+      <i class="fas fa-search"></i>
+      <p>{{localize "SEASONS_STARS.dialog.calendar_selection.no_results"}}</p>
+    </div>
+    {{/unless}}
+  </div>
+</section>


### PR DESCRIPTION
## Summary

Redesign the calendar selection dialog from a bulky card-grid layout to a streamlined master-detail pattern with improved usability.

### Layout Changes
- Master-detail pattern with 35%/65% split (list/detail)
- Compact scrollable list showing many calendars at once
- Detail pane shows full calendar information with interactive month browser
- Search input with tag filter dropdown (tags pending metadata integration)

### Interaction Improvements
- Single click on calendar selects it and shows details
- No need to scroll to find "Select" button - list click = selection
- Footer button confirms the choice

### Visual Design
- "Well" style container for sample date and month browser (matches main widget)
- Theme-aware inset shadows for light/dark modes
- Subtle 2px borders between major sections
- Consistent button contrast across game system themes

### Custom File Picker
- Single-row inline layout (label, path, actions on one line)
- Clear visual indication it's a single file selection, not a list
- Status badges for "Selected" and "Currently Active" states

### Template Structure
- Split into 5 ApplicationV2 PARTS for selective re-rendering:
  - `header.hbs`: search and filter controls
  - `list.hbs`: compact calendar list with variant grouping
  - `detail.hbs`: interactive calendar preview
  - `file-picker.hbs`: custom calendar file section
  - `footer.hbs`: cancel/confirm buttons

## Test plan
- [ ] Open calendar selection dialog from settings
- [ ] Verify list displays calendars compactly
- [ ] Click a calendar - should select it and show details
- [ ] Verify month browser navigation works (prev/next buttons)
- [ ] Test custom file picker: browse, select file, clear file
- [ ] Test search input filters list
- [ ] Verify dialog works in different game systems (D&D 5e, PF2e, Dragonbane)
- [ ] Confirm footer "Use This Calendar" button applies selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)