### PR TITLE
fix: prevent spurious day change notification on page refresh

### DIFF
--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -462,6 +462,14 @@ Hooks.once('ready', async () => {
   try {
     const currentDate = calendarManager.getCurrentDate();
     if (currentDate) {
+      // Initialize lastEventCheckDate to current date to prevent
+      // spurious day change notifications on first time advancement after page refresh
+      lastEventCheckDate = {
+        year: currentDate.year,
+        month: currentDate.month,
+        day: currentDate.day,
+      };
+
       // Get events for current date with visibility filtering
       const events = eventsAPI.getEventsForDate(
         currentDate.year,
@@ -480,13 +488,6 @@ Hooks.once('ready', async () => {
           isStartup: true,
           // No previousDate on startup
         });
-
-        // Update lastEventCheckDate to prevent duplicate hook fire on first dateChanged
-        lastEventCheckDate = {
-          year: currentDate.year,
-          month: currentDate.month,
-          day: currentDate.day,
-        };
       }
     }
   } catch (error) {


### PR DESCRIPTION
## Summary
- Fixes bug where day change notification re-announced the day after refreshing the page if any time advancement occurred
- Day announcements now only fire when the day actually crosses a threshold

## Root Cause
The `lastEventCheckDate` variable was only being set on startup when there were events on the current date. If there were no events, it remained `null`, causing the first time update after page refresh to be treated as a day change (since `null !== currentDate`).

## Fix
Initialize `lastEventCheckDate` unconditionally to the current date on startup, regardless of whether events exist for that date.

## Test plan
- [x] All 2401 tests pass
- [x] Lint passes
- [x] Typecheck passes
- [x] Build succeeds
- [ ] Manual testing: refresh page, advance time by minutes/hours - should NOT re-announce the day
- [ ] Manual testing: advance time to next day - SHOULD announce the new day

🤖 Generated with [Claude Code](https://claude.com/claude-code)