### PR TITLE
refactor: use Foundry's saveDataToFile for calendar export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10484,7 +10484,7 @@
     },
     "packages/core": {
       "name": "seasons-and-stars",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
@@ -10559,7 +10559,7 @@
     },
     "packages/custom-calendar-builder": {
       "name": "seasons-and-stars-calendar-builder",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",

--- a/packages/core/src/types/foundry-extensions.d.ts
+++ b/packages/core/src/types/foundry-extensions.d.ts
@@ -88,6 +88,7 @@ declare global {
       function mergeObject(original: any, other: any, options?: any): any;
       function deepClone(obj: any): any;
       function debounce<T extends (...args: any[]) => any>(fn: T, delay: number): T;
+      function saveDataToFile(data: string, type: string, filename: string): void;
     }
   }
   interface String {

--- a/packages/custom-calendar-builder/src/calendar-builder-app.ts
+++ b/packages/custom-calendar-builder/src/calendar-builder-app.ts
@@ -721,24 +721,7 @@ export class CalendarBuilderApp extends foundry.applications.api.HandlebarsAppli
     }
 
     try {
-      // Create blob and download link
-      const blob = new Blob([this.currentJson], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'custom-calendar.json';
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-
-      // Delay cleanup to ensure browser has time to process the download
-      // Fixes "Your PC doesn't have an app that can open this link" error on Windows
-      // where immediate revocation prevents the download from starting
-      setTimeout(() => {
-        URL.revokeObjectURL(url);
-      }, 100);
-
+      foundry.utils.saveDataToFile(this.currentJson, 'application/json', 'custom-calendar.json');
       this._notify(game.i18n.localize('CALENDAR_BUILDER.app.notifications.exported'));
     } catch (error) {
       console.error('Export failed:', error);

--- a/packages/custom-calendar-builder/test/calendar-builder-app.test.ts
+++ b/packages/custom-calendar-builder/test/calendar-builder-app.test.ts
@@ -25,6 +25,9 @@ const mockFoundry = {
       }),
     },
   },
+  utils: {
+    saveDataToFile: vi.fn(),
+  },
 };
 
 const mockGame = {


### PR DESCRIPTION
Replace custom blob/download code with Foundry's built-in
saveDataToFile utility function for exporting calendars in the
Calendar Builder app.

- Use foundry.utils.saveDataToFile instead of manual blob handling
- Add saveDataToFile type declaration to foundry-extensions.d.ts
- Update test mock to include the new function